### PR TITLE
Passing Suite reference to a batch

### DIFF
--- a/lib/vows/suite.js
+++ b/lib/vows/suite.js
@@ -107,6 +107,8 @@ this.Suite.prototype = new(function () {
             tests   = batch.tests,
             promise = batch.promise = new(events.EventEmitter);
 
+        var that = this;
+
         batch.status = 'begin';
 
         // The test runner, it calls itself recursively, passing the
@@ -169,6 +171,7 @@ this.Suite.prototype = new(function () {
                 // Create a new evaluation context,
                 // inheriting from the parent one.
                 var env = Object.create(ctx.env);
+                env.suite = that;
 
                 // Holds the current test or context
                 var vow = Object.create({


### PR DESCRIPTION
Would you consider a patch that will pass Suite reference down to batches? I utterly need to accomplish that to make a better use of my chained vows definitions — something like vows.describe('User authentication').withIsolatedDatabase().addBatch(...). In this scenario I need to pass a reference to an isolated database instance and I found no way to accomplish that without passing Suite reference down to batches. Or may be you have another idea how that could be done?
