### PR TITLE
Two patches to support barista_test: Bug fix + requiring modules from the command line

### DIFF
--- a/bin/vows
+++ b/bin/vows
@@ -49,6 +49,7 @@ var help = [
     "  --spec            Use Spec reporter",
     "  --dot-matrix      Use Dot-Matrix reporter",
     //"  --no-color        Don't use terminal colors",
+    "  -R MODULE         Require a module before running specs",
     "  --version         Show version",
     "  -h, --help        You're staring at it"
 ].join('\n');
@@ -88,6 +89,8 @@ while (arg = argv.shift()) {
                     regex    = new(RegExp)('(\\' + specials + ')', 'g');
                 return new(RegExp)(str.replace(regex, '\\$1'));
             })(argv.shift());
+        } else if (arg[0] == 'R') {
+            require(argv.shift());
         } else if (arg in options) {
             options[arg] = true;
         } else {


### PR DESCRIPTION
Good afternoon! Thank you for releasing such a nice BDD library for Node.js. I hope to make it really easy for Rails and CoffeeScript users to take advantage of your work, so I'm writing a Rails plugin that will eventually be merged into Barista (which is a popular library for using CoffeeScript with Rails).

One of these two patches is a minor bugfix, previously submitted. The other patch adds support for pre-requiring commonly-used modules before running the specs, and is intended for preloading modules such as sinon or jsdom at a user's request.

Thank you for considering my patches! I'd be happy to rewrite them to better fit the needs of Vow.js, so please feel free to make suggestions or suggest alternate approaches!
