### PR TITLE
A patch to run teardown after subcontexts complete

### DIFF
--- a/lib/vows/suite.js
+++ b/lib/vows/suite.js
@@ -30,6 +30,7 @@ this.Suite.prototype = new(function () {
             b.remaining = b._remaining;
             b.honored = b.broken = b.errored = b.total = b.pending = 0;
             b.vows.forEach(function (vow) { vow.status = null });
+            b.teardowns = [];
         });
     };
 
@@ -44,7 +45,8 @@ this.Suite.prototype = new(function () {
             broken:    0,
             errored:   0,
             pending:   0,
-            total:     0
+            total:     0,
+            teardowns: []
         });
         return this;
     };
@@ -206,11 +208,9 @@ this.Suite.prototype = new(function () {
                 }
             });
             // Teardown
-            topic.addListener("success", function () {
-                if (ctx.tests.teardown) {
-                    ctx.tests.teardown.apply(ctx.env, ctx.topics);
-                }
-            });
+            if (ctx.tests.teardown) {
+                batch.teardowns.push(ctx);
+            }
             if (! ctx.tests._skip) {
                 batch.remaining --;
             }
@@ -301,6 +301,13 @@ this.tryEnd = function (batch) {
         Object.keys(batch).forEach(function (k) {
             (k in batch.suite.results) && (batch.suite.results[k] += batch[k]);
         });
+
+        if(batch.teardowns) {
+            while(batch.teardowns.length > 0) {
+                var ctx = batch.teardowns.pop();
+                ctx.tests.teardown.apply(ctx.env, ctx.topics);
+            }
+        }
 
         batch.status = 'end';
         batch.suite.report(['end']);

--- a/test/vows-test.js
+++ b/test/vows-test.js
@@ -317,6 +317,17 @@ vows.describe("Vows with teardowns").addBatch({
         },
         teardown: function (topic) {
             topic.flag = false;
+        },
+        "with a subcontext" : {
+            topic: function (topic) {
+                var that = this;
+                process.nextTick(function () {
+                    that.callback(null, topic);
+                });
+            },
+            "Waits for the subcontext before teardown" : function(topic) {
+                assert.isTrue(topic.flag);
+            }
         }
     }
 }).export(module);


### PR DESCRIPTION
Hello!

Thank you for this great framework you've been building!  I was wanting to use the teardown method after successful execution of subflows rather than on topic success, and I noticed that others wanted the same thing.

I went ahead and implemented it in what seemed the cleanest way for me. The idea here is that batches now maintain a stack of context objects, 1 for each teardown method. The assumption in the code is that no teardowns should ever run until the innermost vows have all completed. Because of that, I moved the execution of the teardowns into the tryEnd method. It simply pops the context objects and executes their teardown method.

Potential issues:
- I didn't initially have the line 'if(batch.teardowns)' in the code, but I kept getting an undefined for batch.teardowns on some of the tests, despite having added teardowns to the addBatch method. I'm not sure where else it might go away, but I assume you would.
- The teardowns end up getting run synchronously, 1 after the other. This seems acceptable though, to ensure that the teardowns run after all vows and before the batch ends.
- My test is very basic, and just added to your initial teardown test. I imagine that a test verifying the correct order of execution with multiple nested contexts would be ideal, but I had a concern about uglying up these nice looking tests.

Please let me know what you think about this commit!

Thanks,

Jeremiah
