### PR TITLE
add assert.deepInclude

### DIFF
--- a/lib/assert/macros.js
+++ b/lib/assert/macros.js
@@ -1,4 +1,5 @@
-var assert = require('assert');
+var assert = require('assert'),
+    utils = require('assert/utils');
 
 var messages = {
     'equal'       : "expected {expected},\n\tgot\t {actual} ({operator})",
@@ -77,6 +78,16 @@ assert.include = function (actual, expected, message) {
 };
 assert.includes = assert.include;
 
+assert.deepInclude = function (actual, expected, message) {
+    if (!isArray(actual)) {
+        return assert.include(actual, expected, message);
+    }
+    if (!actual.some(function (item) { return utils.deepEqual(item, expected) })) {
+        assert.fail(actual, expected, message || "expected {actual} to include {expected}", "include", assert.deepInclude);
+    }
+};
+assert.deepIncludes = assert.deepInclude;
+
 //
 // Length
 //
@@ -146,6 +157,7 @@ assert.instanceOf = function (actual, expected, message) {
 //
 // Utility functions
 //
+
 function assertTypeOf(actual, expected, message, caller) {
     if (typeOf(actual) !== expected) {
         assert.fail(actual, expected, message || "expected {actual} to be of type {expected}", "typeOf", caller);

--- a/lib/assert/utils.js
+++ b/lib/assert/utils.js
@@ -1,0 +1,77 @@
+
+// Taken from node/lib/assert.js
+exports.deepEqual = function (actual, expected) {
+  if (actual === expected) {
+    return true;
+
+  } else if (Buffer.isBuffer(actual) && Buffer.isBuffer(expected)) {
+    if (actual.length != expected.length) return false;
+
+    for (var i = 0; i < actual.length; i++) {
+      if (actual[i] !== expected[i]) return false;
+    }
+    return true;
+
+  } else if (actual instanceof Date && expected instanceof Date) {
+    return actual.getTime() === expected.getTime();
+
+  } else if (typeof actual != 'object' && typeof expected != 'object') {
+    return actual == expected;
+
+  } else {
+    return objEquiv(actual, expected);
+  }
+}
+
+// Taken from node/lib/assert.js
+exports.notDeepEqual = function (actual, expected, message) {
+  if (exports.deepEqual(actual, expected)) {
+    fail(actual, expected, message, 'notDeepEqual', assert.notDeepEqual);
+  }
+}
+
+// Taken from node/lib/assert.js
+function isUndefinedOrNull(value) {
+  return value === null || value === undefined;
+}
+
+// Taken from node/lib/assert.js
+function isArguments(object) {
+  return Object.prototype.toString.call(object) == '[object Arguments]';
+}
+
+// Taken from node/lib/assert.js
+function objEquiv(a, b) {
+  if (isUndefinedOrNull(a) || isUndefinedOrNull(b))
+    return false;
+  if (a.prototype !== b.prototype) return false;
+  if (isArguments(a)) {
+    if (!isArguments(b)) {
+      return false;
+    }
+    a = pSlice.call(a);
+    b = pSlice.call(b);
+    return exports.deepEqual(a, b);
+  }
+  try {
+    var ka = Object.keys(a),
+        kb = Object.keys(b),
+        key, i;
+  } catch (e) {
+    return false;
+  }
+  if (ka.length != kb.length)
+    return false;
+  ka.sort();
+  kb.sort();
+  for (i = ka.length - 1; i >= 0; i--) {
+    if (ka[i] != kb[i])
+      return false;
+  }
+  for (i = ka.length - 1; i >= 0; i--) {
+    key = ka[i];
+    if (!exports.deepEqual(a[key], b[key])) return false;
+  }
+  return true;
+}
+

--- a/test/assert-test.js
+++ b/test/assert-test.js
@@ -21,6 +21,11 @@ vows.describe('vows/assert').addBatch({
             assert.include([0, 42, 0],    42);
             assert.include({goo:true},    'goo');
         },
+        "`deepInclude`": function (assert) {
+            assert.deepInclude([{a:'b'},{c:'d'}], {a:'b'});
+            assert.deepInclude("hello world", "world");
+            assert.deepInclude({goo:true},    'goo');
+        },
         "`typeOf`": function (assert) {
             assert.typeOf('goo', 'string');
             assert.typeOf(42,    'number');


### PR DESCRIPTION
Like `assert.include`, but works with collections of objects.

```
assert.deepInclude([{a:'b'},{c:'d'}], {a:'b'});
```

If `actual` isn't an array, defers to `assert.include`.

Note: had to pull in `deepEqual` from node/lib/assert.js into `utils.deepEqual`.
