### PR TITLE
Add support for asynchronous teardowns

### DIFF
--- a/lib/vows/suite.js
+++ b/lib/vows/suite.js
@@ -306,16 +306,45 @@ this.tryEnd = function (batch) {
             (k in batch.suite.results) && (batch.suite.results[k] += batch[k]);
         });
 
-        // Run teardowns
         if (batch.teardowns) {
             for (var i = batch.teardowns.length - 1, ctx; i >= 0; i--) {
-                ctx = batch.teardowns[i];
-                ctx.tests.teardown.apply(ctx.env, ctx.topics);
+                runTeardown(batch.teardowns[i]);
             }
+
+            maybeFinish();
         }
 
-        batch.status = 'end';
-        batch.suite.report(['end']);
-        batch.promise.emit('end', batch.honored, batch.broken, batch.errored, batch.pending);
+        function runTeardown(teardown) {
+            var env = Object.create(teardown.env);
+
+            Object.defineProperty(env, "callback", {
+                get: function () {
+                    teardown.awaitingCallback = true;
+    
+                    return function () {
+                        teardown.awaitingCallback = false;
+                        maybeFinish();
+                    };
+                }
+            })
+
+            teardown.tests.teardown.apply(env, teardown.topics);
+        }
+
+        function maybeFinish() {
+          var pending = batch.teardowns.filter(function (teardown) {
+              return teardown.awaitingCallback;
+          });
+
+          if (pending.length === 0) {
+              finish();
+          }
+        }
+
+        function finish() {
+            batch.status = 'end';
+            batch.suite.report(['end']);
+            batch.promise.emit('end', batch.honored, batch.broken, batch.errored, batch.pending);
+        }
     }
 };

--- a/test/vows-test.js
+++ b/test/vows-test.js
@@ -371,3 +371,24 @@ vows.describe("Vows with teardowns").addBatch({
     }
 }).export(module);
 
+var tornDown = false
+
+vows.describe("Vows with asynchonous teardowns").addBatch({
+    "Context with long-running teardown": {
+        "is run first": function () {},
+        teardown: function () {
+            var callback = this.callback;
+
+            setTimeout(function () {
+                tornDown = true;
+                callback();
+            }, 100);
+        }
+    }
+}).addBatch({
+    "The next batch": {
+        "is not run until the teardown is complete": function () {
+            assert.ok(tornDown)
+        }
+    }
+}).export(module);


### PR DESCRIPTION
As far as I can tell, Vows currently does not support asynchronous teardowns. This becomes especially problematic because the `vows` program will shut down execution using `process.exit` before the teardown function has had a chance to finish its job.

Since we cannot distinguish between synchronous and asynchronous using the return value as is done for topic functions (since teardown functions do not return anything), my patch utilizes the fact that we can at least detect when the teardown function grabs `this.callback`. This means that the teardown function must access `this.callback` before returning (i.e., synchronously), in order to signal to the framework that it has more work to do.
