### PR TITLE
Fix error when file arg uses absolute path

### DIFF
--- a/bin/vows
+++ b/bin/vows
@@ -196,7 +196,9 @@ if (! options.watch) {
     reporter.print = _reporter.print;
 
     files = args.map(function (a) {
-        return path.join(process.cwd(), a.replace(fileExt, ''));
+        return (!a.match(/^\//))
+            ? path.join(process.cwd(), a.replace(fileExt, ''))
+            : a.replace(fileExt, '');
     });
 
     runSuites(importSuites(files), function (results) {


### PR DESCRIPTION
'vows /absolute/path/to/testfile.js' results in an error because the current working directory is appended to the file arg.
Here's an example error message:
node.js:134
        throw e; // process.nextTick error, or 'error' event on first tick
        ^
Error: Cannot find module '/absolute/path/current/working/directory/absolute/path/to/testfile'
    at Function._resolveFilename (module.js:320:11)
    at Function._load (module.js:266:25)
    at require (module.js:348:19)
    at /foobar/.npm/vows/0.5.8/package/bin/vows:369:19
    at Array.reduce (native)
    at importSuites (/foobar/.npm/vows/0.5.8/package/bin/vows:368:18)
    at Object.<anonymous> (/foobar/.npm/vows/0.5.8/package/bin/vows:202:15)
    at Module._compile (module.js:404:26)
    at Object..js (module.js:410:10)
    at Module.load (module.js:336:31)

Tested with node 0.4.5 on osx
