### PR TITLE
Replaces backticks in broken expectation output, as seen in printed SQL s

### DIFF
--- a/lib/vows.js
+++ b/lib/vows.js
@@ -96,7 +96,7 @@ function addVow(vow) {
             output('honored');
         } catch (e) {
             if (e.name && e.name.match(/AssertionError/)) {
-                output('broken', e.toString());
+                output('broken', e.toString().replace(/\`/g, '`'));
             } else {
                 output('errored', e.stack || e.message || e);
             }


### PR DESCRIPTION
Replaces backticks in broken expectation output, as seen in printed SQL statements where table or field names are escaped.
