### PR TITLE
Fix the declaration of stylize.

### DIFF
--- a/lib/vows/console.js
+++ b/lib/vows/console.js
@@ -1,7 +1,7 @@
 var eyes = require('eyes').inspector({ stream: null, styles: false });
 
 // Stylize a string
-this.stylize = function stylize(str, style) {
+var stylize = this.stylize = function (str, style) {
     var styles = {
         'bold'      : [1,  22],
         'italic'    : [3,  23],


### PR DESCRIPTION
When a named function is used as part of an assignment, the function name is not hoisted. So, we must declare a var for it to be called as `stylize`. This was probably due to commit @f18b45cacdfe02872e4fa257b19b468b0be62c1d.
