### PR TITLE
Allow arguments to flow through to callbacks in error conditions.

### DIFF
--- a/lib/vows.js
+++ b/lib/vows.js
@@ -73,7 +73,7 @@ function addVow(vow) {
 
     }).on("error", function (err) {
         if (vow.callback.length >= 2 || !batch.suite.options.error) {
-            runTest([err], this.ctx);
+            runTest(arguments, this.ctx);
         } else {
             output('errored', { type: 'promise', error: err.stack || err.message || JSON.stringify(err) });
         }

--- a/lib/vows/context.js
+++ b/lib/vows/context.js
@@ -28,7 +28,7 @@ this.Context = function (vow, ctx, env) {
                     if (typeof(e) === 'boolean' && args.length === 0) {
                         that.emitter.emit.call(that.emitter, 'success', e);
                     } else {
-                        if (e) { that.emitter.emit.call(that.emitter, 'error', e) }
+                        if (e) { that.emitter.emit.apply(that.emitter, ['error', e].concat(args)) }
                         else   { that.emitter.emit.apply(that.emitter, ['success'].concat(args)) }
                     }
                 };

--- a/lib/vows/extras.js
+++ b/lib/vows/extras.js
@@ -13,7 +13,7 @@ this.prepare = function (obj, targets) {
                     args.push(function (err /* [, data] */) {
                         var args = Array.prototype.slice.call(arguments, 1);
 
-                        if (err) { ee.emit('error', err) }
+                        if (err) { ee.emit.apply(ee, ['error', err].concat(args)) }
                         else     { ee.emit.apply(ee, ['success'].concat(args)) }
                     });
                     fun.apply(obj, args);


### PR DESCRIPTION
Topic callbacks should receive all arguments passed in error situations.  Currently only the first argument
is passed to the callback function regardless of how many arguments are sent.

See https://gist.github.com/1152218 for example showing this behavior.
