### PR TITLE
Handle the case where a topic function throws

### DIFF
--- a/lib/vows/suite.js
+++ b/lib/vows/suite.js
@@ -125,7 +125,20 @@ this.Suite.prototype = new(function () {
 
             if (typeof(topic) === 'function') {
                 // Run the topic, passing the previous context topics
-                topic = topic.apply(ctx.env, ctx.topics);
+                try {
+                    topic = topic.apply(ctx.env, ctx.topics);
+                }
+                catch(ex) {
+                    // The topic threw an exception while being executed. 
+                    // We cannot know whether it was going to be a callback-style
+                    // topic or not. We just ignore it and have it emit an error
+                    // with the execption message attached.
+                    ctx.emitter = new(events.EventEmitter);
+                    process.nextTick(function(){
+                        return function(){ ctx.emitter.emit("error", ex.toString()); };
+                    }(topic));
+                    topic = ctx.emitter;
+                }
 
                 if (typeof(topic) === 'undefined') { ctx._callback = true }
             }

--- a/test/vows-error-test.js
+++ b/test/vows-error-test.js
@@ -22,7 +22,7 @@ function doSomethingAsyncWithError(callback) {
   	});
 }
 
-
+var batchCount = 0;
 vows.describe('vows/error').addBatch({
 	'Generate success response to async function': {
     		topic: function() {
@@ -47,5 +47,43 @@ vows.describe('vows/error').addBatch({
     			  // This assertion fails. It shouldn't.
     			  assert.equal(testValue, 'a');
     		}
-  	}
-}).export(module)
+  	},
+
+   'Generate a hard error in the topic': {
+       topic: function(){ ({}).unknownMethod(this.callback); },
+       'should not stop vows': function(){ assert.equal(arguments.length,1); }
+   },
+
+   'In a batch': {
+       'generate an exception in the first topic': {
+           topic: function(){ ({}).unknownMethod(this.callback); },
+           'vow': function(){ ++batchCount; }
+       },
+       'ensure the second topic runs': {
+           topic: function(){ return {}; },
+           'vow': function(){ ++batchCount; },
+       }
+   }
+}).addBatch({
+   'Next batch running sequentially': {
+       topic: function(){ return batchCount; },
+       'checks that the batchCount is 1': function(b){ assert.equal(b, 1); }
+   }
+}).addBatch({
+    'Outer batch': {
+        'Nested batch': {
+            'Nested(2) batch: topic throws': {
+                topic: function(){ ({}).unknownMethod(this.callback); },
+                'vow 1': function(){},
+                'vow 2': function(){},
+            }
+        },
+        'Nested(2) batch decreases batchCount': {
+            topic: function(){ batchCount--; return batchCount; },
+            'vow': function(b){ assert.equal(b, 0); },
+        }
+    }
+}).export(module);
+
+
+


### PR DESCRIPTION
If a topic function throws, instead of stopping the whole testing
process, it now reports all associated vows as failing.

Rational: I often write tests for API that do not exist yet and currently, vows stops mid-run and report an exception instead of reporting a failing test and continuing on.
I thought that could be useful.
