### PR TITLE
Display exceptions in watch mode

### DIFF
--- a/bin/vows
+++ b/bin/vows
@@ -192,9 +192,7 @@ if (args.length === 0 || options.watch) {
     }
     msg('bin', 'discovered', "./" + testFolder);
     if (args.length === 0) {
-        console.log(fileExt)
         args = paths(testFolder).filter(function (f) {
-            console.log(f)
             return new(RegExp)('-' + testFolder + '.(js|coffee)$').test(f);
         });
 


### PR DESCRIPTION
In the current version, uncaught exceptions are not showed in watch mode. 
This is a 1 line fix to print it and continue the watch.
