### PR TITLE
Use pre-compiled regex when searching for all test/spec files.

### DIFF
--- a/bin/vows
+++ b/bin/vows
@@ -194,7 +194,7 @@ if (args.length === 0 || options.watch) {
 
     if (args.length === 0) {
         args = paths(testFolder).filter(function (f) {
-            return new(RegExp)('-' + testFolder + '.(js|coffee)$').test(f);
+            return specFileExt.test(f);
         });
 
         if (options.watch) {


### PR DESCRIPTION
Rather than create a new RegExp object for every file found in the test or spec directory, just use the one defined at the top which is also aware of coffeescript support.

This catches files with either test or spec at the end rather than just the one corresponding to the directory name, but that could be desirable. I only noticed because my *.test.js files weren't being found anyway.
