### PR TITLE
Add support for coffee files when printing errors

### DIFF
--- a/lib/assert/error.js
+++ b/lib/assert/error.js
@@ -3,7 +3,7 @@ var inspect = require('../vows/console').inspect;
 
 require('assert').AssertionError.prototype.toString = function () {
     var that = this,
-        source = this.stack.match(/([a-zA-Z0-9._-]+\.js)(:\d+):\d+/);
+        source = this.stack.match(/([a-zA-Z0-9._-]+\.(?:js|coffee))(:\d+):\d+/);
 
     function parse(str) {
         return str.replace(/{actual}/g,   inspect(that.actual)).


### PR DESCRIPTION
I ran into a problem that when I was getting an assertion error in a coffee file, it was crashing because the regular expression for pulling out the filename was restricted to .js files.  Just added a simple addition to accept coffee files also.
