### PR TITLE
[fix] Fix failed assertions output

### DIFF
--- a/lib/assert/error.js
+++ b/lib/assert/error.js
@@ -19,7 +19,7 @@ require('assert').AssertionError.prototype.toString = function () {
 
     if (this.message) {
         return stylize(parse(this.message), 'yellow') +
-               (source) ? stylize(' // ' + source[1] + source[2], 'grey') : '';
+               ((source) ? stylize(' // ' + source[1] + source[2], 'grey') : '');
     } else {
         return stylize([
             this.expected,


### PR DESCRIPTION
Latest changes made to Vows in order to make it compatible with `node
v0.5.x` (see issue #141) introduce a bug which caused Vows to output
only file name and line when assertion fails:

```
when testing
  ✗ should output details
    »  // test.js:8
```

This turned out to be a really small bug. Output works now:

```
when testing
  ✗ should output details
    » expected { a: 1, b: 3 },
      got      { a: 1, b: 2 } (deepEqual) // test.js:8
```

Sorry for that.
