### PR TITLE
[v0.6 fix] Properly inspect errors

### DIFF
--- a/lib/assert/error.js
+++ b/lib/assert/error.js
@@ -10,11 +10,19 @@ require('assert').AssertionError.prototype.toString = function () {
     }
 
     function parse(str) {
-        return str.replace(/{actual}/g,   inspect(that.actual)).
+        var actual = inspect(that.actual, {showHidden: that.actual instanceof Error}),
+            expected;
+
+        if (that.expected instanceof Function) {
+            expected = that.expected.name;
+        }
+        else {
+            expected = inspect(that.expected, {showHidden: that.actual instanceof Error});
+        }
+
+        return str.replace(/{actual}/g,   actual).
                    replace(/{operator}/g, stylize(that.operator, 'bold')).
-                   replace(/{expected}/g, (that.expected instanceof Function)
-                                          ? that.expected.name
-                                          : inspect(that.expected));
+                   replace(/{expected}/g, expected);
     }
 
     if (this.message) {


### PR DESCRIPTION
This is related and blocked by cloudhead/eyes.js#12.

Gist of what's going on: `Error` properties are non-enumerable in `node v0.6`, so `Object.keys` which is being used in `eyes.js` won't list them (we need to use `Object.getOwnPropertyNames`). This results in errors being outputted as `{}`, for example in `assert.isNull(err)` statement.

(Also, reformatted this code a bit)
