### PR TITLE
Fixes #31: Add --no-color option to suppress terminal colors

### DIFF
--- a/bin/vows
+++ b/bin/vows
@@ -59,7 +59,7 @@ var help = [
     "  --cover-plain     Print plain coverage map if detected",
     "  --cover-html      Write coverage map to \"coverage.html\"",
     "  --cover-json      Write unified coverage map to \"coverage.json\"",
-    //"  --no-color        Don't use terminal colors",
+    "  --no-color        Don't use terminal colors",
     "  --version         Show version",
     "  -h, --help        You're staring at it"
 ].join('\n');
@@ -69,7 +69,8 @@ var options = {
     matcher: /.*/,
     watch: false,
     coverage: false,
-    isolate: false
+    isolate: false,
+    nocolor: !process.stdout.isTTY
 };
 
 var files = [];
@@ -151,6 +152,9 @@ while (arg = argv.shift()) {
                 case 'no-color':
                     options.nocolor = true;
                     break;
+                case 'color':
+                    options.nocolor = false;
+                    break;
                 case 'no-error':
                     options.error = false;
                     break;
@@ -165,6 +169,11 @@ while (arg = argv.shift()) {
             }
         }
     }
+}
+
+if (options.nocolor) {
+    cutils.nocolor = true;
+    inspect = require('eyes').inspector({ stream: null, styles: false });
 }
 
 if (options.supressStdout) {

--- a/lib/vows/console.js
+++ b/lib/vows/console.js
@@ -2,6 +2,9 @@ var eyes = require('eyes').inspector({ stream: null, styles: false });
 
 // Stylize a string
 this.stylize = function stylize(str, style) {
+    if (module.exports.nocolor)
+        return str;
+    
     var styles = {
         'bold'      : [1,  22],
         'italic'    : [3,  23],
@@ -85,6 +88,8 @@ this.result = function (event) {
 };
 
 this.inspect = function inspect(val) {
+    if (module.exports.nocolor)
+        return eyes(val);
     return '\033[1m' + eyes(val) + '\033[22m';
 };
 


### PR DESCRIPTION
See issue #31.
The colors will be automatically suppressed if the stdout is not a TTY. 
Also added (undocumented) --color command to force colors even if we are not outputting to a terminal.
