### PR TITLE
Synchronous Vows

### DIFF
--- a/lib/vows.js
+++ b/lib/vows.js
@@ -62,6 +62,8 @@ function addVow(vow) {
 
     batch.total ++;
     batch.vows.push(vow);
+    
+    vow.binding.context.addVow(vow);
 
     // always set a listener on the event
     this.on(event, function () {
@@ -76,7 +78,7 @@ function addVow(vow) {
             args.unshift(null);
         }
         runTest(args, this.ctx);
-        vows.tryEnd(batch);
+        vows.tryEnd(batch, vow);
     });
 
     if (event !== 'error') {
@@ -87,7 +89,7 @@ function addVow(vow) {
                 output('errored', { type: 'promise', error: err.stack ||
                        err.message || JSON.stringify(err) });
             }
-            vows.tryEnd(batch);
+            vows.tryEnd(batch, vow);
         });
     }
 
@@ -105,7 +107,7 @@ function addVow(vow) {
             // initial conditions problem
             throw new Error('_vowsEmitedEvents[' + event + '] is not an Array')
         }
-        vows.tryEnd(batch);
+        vows.tryEnd(batch, vow);
     }
 
     return this;

--- a/lib/vows/context.js
+++ b/lib/vows/context.js
@@ -1,12 +1,18 @@
 
-this.Context = function (vow, ctx, env) {
+var Context = this.Context = function (vow, ctx, env) {
     var that = this;
+
+    // so we can get to adjacent contexts
+    ctx.children = ctx.children || [];
+    ctx.children.push(this);
+    this.parent = ctx;
 
     this.tests = vow.callback;
     this.topics = (ctx.topics || []).slice(0);
     this.emitter = null;
     this.env = env || {};
     this.env.context = this;
+    this._vows = {};
 
     this.env.callback = function (/* arguments */) {
         var ctx = this;
@@ -72,5 +78,45 @@ this.Context = function (vow, ctx, env) {
         ctx.title || '',
         vow.description || ''
     ].join(/^[#.:]/.test(vow.description) ? '' : ' ').trim();
+};
+
+require('util').inherits(Context, require('events').EventEmitter);
+
+// computes the topics that need to be passed as arguments to a given topic
+Context.prototype.nextTopics = function() {
+  if (typeof this.tests.next === 'function') {
+      var me = this.parent ? this.parent.children.indexOf(this) : false;
+      if (me && this.parent &&
+          Array.isArray(this.parent.tests)) {
+              return this.parent.children[me - 1].topics.slice();
+          } else {
+              throw new Error('Use of next only allowed in syncronus context');
+          }
+  } else {
+      return this.topics;
+  }
+}
+
+Context.prototype.addVow = function(vow) {
+  this._vows[vow.uuid] = vow;
+};
+
+Context.prototype.tryEnd = function(vow) {
+
+    if (vow) {
+      delete this._vows[vow.uuid];
+    }
+    if (!Object.keys(this._vows).length &&
+        (this.children &&
+        this.children.every(function(c){return c.complete})) ||
+        !this.children) {
+
+        this.complete = true;
+        this.emit('complete');
+        if (this.parent instanceof Context) {
+          this.parent.tryEnd();
+        }
+    }
+    
 };
 

--- a/lib/vows/suite.js
+++ b/lib/vows/suite.js
@@ -66,7 +66,7 @@ this.Suite.prototype = new(function () {
             var match = false;
 
             var keys = Object.keys(tests).filter(function (k) {
-                return k !== 'topic' && k !== 'teardown';
+                return k !== 'topic' && k !== 'teardown' && k !== 'next';
             });
 
             for (var i = 0, key; i < keys.length; i++) {
@@ -121,7 +121,19 @@ this.Suite.prototype = new(function () {
         // passing the topic as an argument.
         (function run(ctx, lastTopic) {
             var old = false;
-            topic = ctx.tests.topic;
+            if (typeof ctx.tests.topic === 'function' &&
+                typeof ctx.tests.next  === 'function') {
+                throw new Error('Context can not contain both topic and next');
+            }
+
+            // if we have tests, we may have a topic
+            if (ctx.tests) {
+                // next functions like topic, except is is passed it's
+                // sibling's topic, insted of it's parent's
+                topic = ctx.tests.hasOwnProperty('topic') ?
+                      ctx.tests.topic : ctx.tests.hasOwnProperty('next') ?
+                      ctx.tests.next : undefined;
+            }
 
             if (typeof(topic) === 'function') {
                 if (ctx.isEvent || ctx.name === 'on') {
@@ -129,9 +141,9 @@ this.Suite.prototype = new(function () {
                 }
 
                 // Run the topic, passing the previous context topics
-                topic = topic.apply(ctx.env, ctx.topics);
+                topic = topic.apply(ctx.env, ctx.nextTopics());
 
-                if (typeof(topic) === 'undefined') { ctx._callback = true }
+                if (typeof(topic) === 'undefined') {ctx._callback = true }
             }
 
             // If this context has a topic, store it in `lastTopic`,
@@ -155,7 +167,6 @@ this.Suite.prototype = new(function () {
                    (ctx.isEvent && !(topic instanceof events.EventEmitter))) {
 
                       ctx.emitter = new(events.EventEmitter);
-
                       if (! ctx._callback) {
                           process.nextTick(function (val) {
                               return function () {
@@ -163,7 +174,13 @@ this.Suite.prototype = new(function () {
                               };
                           }(topic));
                       }
-                      topic = ctx.emitter;
+                      // if I have a callback, push the new topic back up to
+                      // lastTopic
+                      if (ctx._callback) {
+                          lastTopic = topic = ctx.emitter;
+                      } else {
+                          topic = ctx.emitter;
+                      }
                 }
             }
 
@@ -179,10 +196,13 @@ this.Suite.prototype = new(function () {
                 };
             });
             if (topic.setMaxListeners) { topic.setMaxListeners(Infinity) }
+
             // Now run the tests, or sub-contexts
             Object.keys(ctx.tests).filter(function (k) {
                 return ctx.tests[k] && k !== 'topic'    &&
-                                       k !== 'teardown' && !ctx.tests[k]._skip;
+                                       k !== 'teardown' &&
+                                       k !== 'next'     &&
+                                       !ctx.tests[k]._skip;
             }).forEach(function (item) {
                 // Create a new evaluation context,
                 // inheriting from the parent one.
@@ -196,7 +216,8 @@ this.Suite.prototype = new(function () {
                     description: item,
                     binding: ctx.env,
                     status: null,
-                    batch: batch
+                    batch: batch,
+                    uuid: Math.floor(Math.random()*1000)
                 });
 
                 // If we encounter a function, add it to the callbacks
@@ -213,17 +234,40 @@ this.Suite.prototype = new(function () {
                     // If the event has already fired, the context is 'on' or
                     // there is no setup stage, just run the inner context
                     // synchronously.
-                    if (topic &&
-                        ctx.name !== 'on' &&
-                        !topic._vowsEmitedEvents.hasOwnProperty(ctx.event)) {
-                        topic.on(ctx.event, function (ctx) {
-                            return function (val) {
-                                return run(new(Context)(vow, ctx, env), lastTopic);
-                            };
-                        }(ctx));
+                    if (!Array.isArray(ctx.tests) || item === '0') {
+                        if (topic &&
+                            ctx.name !== 'on' &&
+                            !topic._vowsEmitedEvents.hasOwnProperty(ctx.event)) {
+                            topic.on(ctx.event, function (ctx) {
+                                return function (val) {
+                                    return run(new(Context)(vow, ctx, env), lastTopic);
+                                };
+                            }(ctx));
+                        } else {
+                            run(new(Context)(vow, ctx, env), lastTopic);
+                        }
                     } else {
-                        run(new(Context)(vow, ctx, env), lastTopic);
+                        var waitForSibling = (function(ctx, lastTopic) {
+                            return function() {
+                                var sibling = ctx.children[item - 1];
+                                if ((sibling && sibling.complete) || !sibling) {
+                                    run(new(Context)(vow, ctx, env), lastTopic);
+                                } else {
+                                    sibling.on('complete', function(){
+                                        run(new(Context)(vow, ctx, env), lastTopic);
+                                    })
+                                }
+                            }
+                        }(ctx, lastTopic));
+                        if (topic &&
+                            ctx.name !== 'on' &&
+                            !topic._vowsEmitedEvents.hasOwnProperty(ctx.event)) {
+                            topic.on(ctx.event, waitForSibling);
+                        } else {
+                            waitForSibling();
+                        }
                     }
+                    
                 }
             });
             // Teardown
@@ -314,8 +358,12 @@ this.Suite.prototype = new(function () {
 // Checks if all the tests in the batch have been run,
 // and triggers the next batch (if any), by emitting the 'end' event.
 //
-this.tryEnd = function (batch) {
+this.tryEnd = function (batch, vow) {
     var result, style, time;
+
+    if (vow) {
+        vow.binding.context.tryEnd(vow);
+    }
 
     if (batch.honored + batch.broken + batch.errored + batch.pending === batch.total &&
         batch.remaining === 0) {


### PR DESCRIPTION
Array literal and 'next' are syntactic sugar for nested Context.

This should make it easy to run Synchronous vows without a nesting headache.

Detail below, Fixes #53

This is not ready to merge, but I'm off my plane and would like someone to comment before going farther.
Also, the addition of synchronous tests almost make we want to copy the vows-tests.js and re-write every case.  Hopefully I don't need to be that crazy.

context.js
  Context is now an EventEmitter
  Each Context knows it's children and parent
  Each Context also receive an array of vows.
  addVow added to Context.prototype to push vow onto Context.
  nextTopics added to Context.prototype to handle new 'next' declaration to use in synchronous Context
  tryEnd added to Context.prototype to emit event when this Context (and all it's children) are 'complete'

vows.js
  vow.binding.context.addVow, need to add the vow to the Context
  vows.tryEnd(batch, vow), need to pass the vow to tryEnd so we can call Context.tryEnd(vow)

suite.js
  added 'next' to all Object.keys(tests).filter
  you can not have both a topic and a next declaration
  the topic when running all vows is: topic || next.  Need a bit of logic magic to make this work
  use ctx.nextTopics() to get the right topics to pass to the topic function
  add a uuid to the vow object.  (need a better implementation then Math.random())
  if Array.isArray(ctx.tests) we may need to waitForSibling (this is that for the sake of which we did all this)
  tryEnd is defined here, added a vow param, and if we have one, tryEnd the Context
