### PR TITLE
Fixes an error in /bin/vows reading emacs buffer files on OSX

### DIFF
--- a/bin/vows
+++ b/bin/vows
@@ -515,7 +515,7 @@ function paths(dir) {
         stack.push(dir);
         fs.readdirSync(stack.join('/')).forEach(function (file) {
             
-            // Node throws an error running a stat on eMacs buffer files, 
+            // Node throws an error running a stat on Emacs buffer files, 
             // so we place the hidden file validation here, before this happens
             if (file[0] == '.' || file === 'vendor') {
                 return;


### PR DESCRIPTION
At the present, the vows command line tools choke on hidden emacs buffer files on OSX, throwing the following error:

`Error: ENOENT, no such file or directory 'test/.#example-test.js'``

This occurs right at the `statSync` on `line 518`. My humble guess is that the the emacs buffer file is an alias. I have fixed this by simply moving the preliminary file validations before the file is ever `statSync`'ed.

Hope it helps.
