### PR TITLE
Fixed tiny problem in assert - it was throwing errors for me until this fix

### DIFF
--- a/lib/assert/error.js
+++ b/lib/assert/error.js
@@ -26,7 +26,7 @@ require('assert').AssertionError.prototype.toString = function () {
         }
         catch(e) {
             return str;
-	}
+        }
     }
 
     if (this.message) {


### PR DESCRIPTION
On the assertion side - when things are going wrong we can't assume that the 'message' will be a valid string. It might not be. Or might not be defined. Either way, as opposed to throwing errors at 'assert', we should at least allow whatever message we do have to be displayed.
