### PR TITLE
Fix race condition with watch functionality and Emacs .#lock files.

### DIFF
--- a/bin/vows
+++ b/bin/vows
@@ -514,12 +514,13 @@ function paths(dir) {
     (function traverse(dir, stack) {
         stack.push(dir);
         fs.readdirSync(stack.join('/')).forEach(function (file) {
+            if (file[0] == '.' || file === 'vendor')
+                return;
+
             var path = stack.concat([file]).join('/'),
                 stat = fs.statSync(path);
 
-            if (file[0] == '.' || file === 'vendor') {
-                return;
-            } else if (stat.isFile() && fileExt.test(file)) {
+            if (stat.isFile() && fileExt.test(file)) {
                 paths.push(path);
             } else if (stat.isDirectory()) {
                 traverse(file, stack);


### PR DESCRIPTION
When editing a foo.js file, Emacs creates a .#foo.js file in the same directory. When saving foo.js, Emacs removes the .#foo.js file. This used to guard against concurrent edits and cannot be disabled, though it's being discussed: http://lists.gnu.org/archive/html/emacs-devel/2011-07/msg01020.html.

This patch prevents a race condition when vows reads the content of a watched directory, detects .#foo.js, then stat's each file, but by then .#foo.js has been removed. I just moved the file name test before the stat().
