### PR TITLE
Topic error passed to cb

### DIFF
--- a/lib/vows.js
+++ b/lib/vows.js
@@ -73,7 +73,13 @@ function addVow(vow) {
         // pass the error as the first (null) and the result after.
         if (!(this.ctx && this.ctx.isEvent) &&
             vow.callback.length >= 2 && batch.suite.options.error) {
-            args.unshift(null);
+            var e = args[0];
+            if (e.name && e.name.match(/Error/)) {
+              //leave error as first argument
+            } 
+            else {
+              args.unshift(null);
+            }
         }
         runTest(args, this.ctx);
         vows.tryEnd(batch);
@@ -126,6 +132,7 @@ function addVow(vow) {
             }
         }
 
+        
         // Run the test, and try to catch `AssertionError`s and other exceptions;
         // increment counters accordingly.
         try {

--- a/test/vows-test.js
+++ b/test/vows-test.js
@@ -286,6 +286,25 @@ vows.describe("Vows").addBatch({
                     assert.deepEqual(val, [1, 2, 3]);
                 }
             }
+        },
+        "when the main topic is successful": {
+          topic: function () {
+            function async(callback) {
+              process.nextTick(function () {
+                callback();
+              });
+            }
+            async(this.callback);
+          },
+          "and a subtopic throws an error": {
+            topic: function() {
+              throw new Error("Callback Error");
+            },
+            "should pass the error to the tests": function(err,result) {
+              assert.isNotNull(err);
+              assert.equal(err.message, "Callback Error");
+            }
+          }
         }
     }
 }).addBatch({


### PR DESCRIPTION
I noticed when performing callback-style tests with Vows and Zombie that errors that occurred midway through the test sequence (e.g. clicking a nonexistent button) weren't being caught in my assertions. Instead, the value argument passed to my Vows assertions were the Error objects being thrown by Zombie. 

It turns out that Vows swallows topic Errors and passes them down as values; this behavior is confusing for callback-style tests, as the error argument comes through as `null` but the value argument is the error. 

The change I'm introducing adjusts that behavior to make sure that callback-style tests receive the Error in the expected argument position. I've added a test as well. 
