### PR TITLE
Programmatically specify reporter in .run()

### DIFF
--- a/lib/vows/suite.js
+++ b/lib/vows/suite.js
@@ -264,7 +264,14 @@ this.Suite.prototype = new(function () {
         for (var k in options) { this.options[k] = options[k] }
 
         this.matcher  = this.options.matcher  || this.matcher;
-        this.reporter = this.options.reporter || this.reporter;
+
+        if (options.reporter) {
+          try {
+            this.reporter = require('./reporters/' + options.reporter);
+          } catch (e) {
+            console.log('Reporter was not found, defaulting to dot-matrix.');
+          }
+        }
 
         this.batches.forEach(function (batch) {
             that.parseBatch(batch, that.matcher);


### PR DESCRIPTION
Unless I missed the existing way of doing this.

Like this:

``` javascript
.run({reporter: 'spec'});
```

If reporter is not found - it would default to dot-matrix.
