### PR TITLE
stop polluting EventEmitter

### DIFF
--- a/lib/vows.js
+++ b/lib/vows.js
@@ -17,12 +17,12 @@
 //
 var util = require('util'),
     path = require('path'),
-    events = require('events'),
+    events = require('EventEmitter2'),
     vows = exports;
 
 // Options
 vows.options = {
-    Emitter: events.EventEmitter,
+    Emitter: events.EventEmitter2,
     reporter: require('./vows/reporters/dot-matrix'),
     matcher: /.*/,
     error: true // Handle "error" event

--- a/lib/vows/extras.js
+++ b/lib/vows/extras.js
@@ -1,4 +1,4 @@
-var events = require('events');
+var events = require('EventEmitter2');
 //
 // Wrap a Node.js style async function into an EventEmmitter
 //
@@ -8,7 +8,7 @@ this.prepare = function (obj, targets) {
             obj[target] = (function (fun) {
                 return function () {
                     var args = Array.prototype.slice.call(arguments);
-                    var ee = new(events.EventEmitter);
+                    var ee = new(events.EventEmitter2);
 
                     args.push(function (err /* [, data] */) {
                         var args = Array.prototype.slice.call(arguments, 1);

--- a/lib/vows/suite.js
+++ b/lib/vows/suite.js
@@ -1,4 +1,4 @@
-var events = require('events'),
+var events = require('EventEmitter2'),
     path = require('path');
 
 var vows = require('../vows');
@@ -105,7 +105,7 @@ this.Suite.prototype = new(function () {
     this.runBatch = function (batch) {
         var topic,
             tests   = batch.tests,
-            promise = batch.promise = new(events.EventEmitter);
+            promise = batch.promise = new(events.EventEmitter2);
 
         var that = this;
 
@@ -153,14 +153,14 @@ this.Suite.prototype = new(function () {
             // If the topic doesn't return an event emitter (such as a promise),
             // we create it ourselves, and emit the value on the next tick.
             if (! (topic &&
-                   topic.constructor === events.EventEmitter)) {
+                   topic.constructor === events.EventEmitter2)) {
                 // If the context is a traditional vow, then a topic can ONLY
                 // be an EventEmitter.  However if the context is a sub-event
                 // then the topic may be an instanceof EventEmitter
                 if (!ctx.isEvent ||
-                   (ctx.isEvent && !(topic instanceof events.EventEmitter))) {
+                   (ctx.isEvent && !(topic instanceof events.EventEmitter2))) {
 
-                      ctx.emitter = new(events.EventEmitter);
+                      ctx.emitter = new(events.EventEmitter2);
 
                       if (! ctx._callback) {
                           process.nextTick(function (val) {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "keywords"      : ["testing", "spec", "test", "BDD"],
   "author"        : "Alexis Sellier <self@cloudhead.net>",
   "contributors"  : [{ "name": "Charlie Robbins", "email": "charlie.robbins@gmail.com" }],
-  "dependencies"  : {"eyes": ">=0.1.6"},
+  "dependencies"  : {"eyes": ">=0.1.6", "eventemitter2": "~0.4.8"},
   "main"          : "./lib/vows",
   "bin"           : { "vows": "./bin/vows" },
   "directories"   : { "test": "./test", "bin": "./bin" },

--- a/test/vows-test.js
+++ b/test/vows-test.js
@@ -1,5 +1,5 @@
 var path   = require('path'),
-    events = require('events'),
+    events = require('EventEmitter2'),
     assert = require('assert'),
     fs     = require('fs'),
     vows   = require('../lib/vows');
@@ -13,7 +13,7 @@ var api = vows.prepare({
 
 var promiser = function (val) {
     return function () {
-        var promise = new(events.EventEmitter);
+        var promise = new(events.EventEmitter2);
         process.nextTick(function () { promise.emit('success', val) });
         return promise;
     }
@@ -181,7 +181,7 @@ vows.describe("Vows").addBatch({
     },
     "A topic emitting an error": {
         topic: function () {
-            var promise = new(events.EventEmitter);
+            var promise = new(events.EventEmitter2);
             process.nextTick(function () {
                 promise.emit("error", 404);
             });
@@ -194,7 +194,7 @@ vows.describe("Vows").addBatch({
     },
     "A topic not emitting an error": {
         topic: function () {
-            var promise = new(events.EventEmitter);
+            var promise = new(events.EventEmitter2);
             process.nextTick(function () {
                 promise.emit("success", true);
             });
@@ -311,7 +311,7 @@ vows.describe("Vows").addBatch({
 }).addBatch({
     "A 2nd batch": {
         topic: function () {
-            var p = new(events.EventEmitter);
+            var p = new(events.EventEmitter2);
             setTimeout(function () {
                 p.emit("success");
             }, 100);
@@ -383,7 +383,7 @@ vows.describe("Vows with teardowns").addBatch({
 vows.describe("Vows with sub events").addBatch({
     "A context with sub-events": {
         topic: function () {
-            var topic = new(events.EventEmitter);
+            var topic = new(events.EventEmitter2);
             topic.emit('before', 'before');
 
             process.nextTick(function () {
@@ -442,9 +442,9 @@ vows.describe("Vows with sub events").addBatch({
     "Sub-events emitted by children of EventEmitter": {
         topic: function() {
             var MyEmitter = function () {
-                events.EventEmitter.call(this);
+                events.EventEmitter2.call(this);
             };
-            require('util').inherits(MyEmitter, events.EventEmitter);
+            require('util').inherits(MyEmitter, events.EventEmitter2);
     
             var topic = new(MyEmitter);
             process.nextTick(function () {
@@ -454,7 +454,7 @@ vows.describe("Vows with sub events").addBatch({
             return topic;
         },
         "will return the emitter for traditional vows" : function (err, ret) {
-            assert.ok(ret instanceof events.EventEmitter);
+            assert.ok(ret instanceof events.EventEmitter2);
         },
         // events is an alias for on
         events: {


### PR DESCRIPTION
vows pollutes the global EventEmitter when it wraps emit().

this causes issues in tests of code that also wraps emit() (such as EventReactor).

this patch simply replaces use of the global EventEmitter with EventEmitter2 -- problem solved.
