### PR TITLE
In topics vows should not catch ReferenceError

### DIFF
--- a/lib/vows/suite.js
+++ b/lib/vows/suite.js
@@ -134,6 +134,7 @@ this.Suite.prototype = new(function () {
                     topic = topic.apply(ctx.env, ctx.topics);
                 }
                 catch (ex) {
+                    if(/ReferenceError/.test(ex)) throw ex;
                     topic = ex;
                 }
 


### PR DESCRIPTION
This test should fail :  

```
var vows = require('vows'),
  assert = require('assert');


vows.describe('A vows test').addBatch({
  'When doing something': {
    topic: function(){
      var self = this;
      anUndefinedObject.log('will throw an exception here');
      setTimeout(function(){
        self.callback(new Error('Ahhh this error is unvisible'));
      }, 100);
    },
    'Then this test must fail': function(err, data){
      assert.ifError(err);
    }
  }
}).export(module);
```

But it passed

```
$ vows test/myTest.js --spec

  ♢ A vows test 

  When doing something
    ✓ Then this test must fail

✓ OK » 1 honored (0.002s) 
```

Now, the error if thrown

```
$ vows test/myTest.js --spec

  ♢ A vows test 

node.js:201
        throw e; // process.nextTick error, or 'error' event on first tick
              ^
ReferenceError: anUndefinedObject is not defined
    at Object.<anonymous> (/home/romain/test-vows/test/myTest.js:9:11)
    at run (/home/romain/vows/lib/vows/suite.js:134:35)
    at EventEmitter.<anonymous> (/home/romain/vows/lib/vows/suite.js:234:40)
    at EventEmitter.<anonymous> (events.js:88:20)
    at EventEmitter.emit (/home/romain/vows/lib/vows.js:236:24)
    at Array.0 (/home/romain/vows/lib/vows/suite.js:169:45)
    at EventEmitter._tickCallback (node.js:192:40)
```
