### PR TITLE
specFileExt should allow CamelCase test filename

### DIFF
--- a/bin/vows
+++ b/bin/vows
@@ -23,10 +23,10 @@ try {
         require.registerExtension('.coffee', function (content) { return coffee.compile(content) });
     }
     fileExt     = /\.(js|coffee)$/;
-    specFileExt = /[.(-|_)](test|spec)\.(js|coffee)$/;
+    specFileExt = /[.(-|_)]((t|T)est|(s|S)pec)\.(js|coffee)$/;
 } catch (_) {
     fileExt     = /\.js$/;
-    specFileExt = /[.(-|_)](test|spec)\.js$/;
+    specFileExt = /[.(-|_)]((t|T)est|(s|S)pec)\.js$/;
 }
 
 var inspect = require('eyes').inspector({

--- a/test/VowsCamelCaseTest.js
+++ b/test/VowsCamelCaseTest.js
@@ -1,0 +1,14 @@
+var vows = require('../lib/vows'),
+    assert = require('assert');
+
+vows.describe("Vows test file with camel case").addBatch({
+
+  "The test file": {
+    topic: function () {
+        return { flag: true };
+    },
+    "is run": function (topic) {
+        assert.isTrue(topic.flag);
+    }
+  }
+}).export(module);


### PR DESCRIPTION
By default vows find tests with the following extensions: 
- xxx-test.js
- xxx_test.js
- xxx-spec.js
- xxx_spec.js

This pull request add the CamelCase extension: 
- xxxTest.js
- xxxSpec.js
