### PR TITLE
Exit code should be 1 if asynchronous errors occur - fix #4

### DIFF
--- a/lib/vows.js
+++ b/lib/vows.js
@@ -202,6 +202,7 @@ process.on('exit', function () {
     });
     if (failure) {
         util.puts(console.result(results));
+        process.exit(1);
     }
 });
 


### PR DESCRIPTION
Regression commit: 692cb71ec2100e0f1dcb3add2d14dc93ef864e9f
