### PR TITLE
Add assert.lengthOf on objects

### DIFF
--- a/lib/assert/macros.js
+++ b/lib/assert/macros.js
@@ -111,7 +111,8 @@ assert.isNotEmpty = function (actual, message) {
 };
 
 assert.lengthOf = function (actual, expected, message) {
-    if (actual.length !== expected) {
+    var len = isObject(actual) ? Object.keys(actual).length : actual.length;
+    if ( len !== expected) {
         assert.fail(actual, expected, message || "expected {actual} to have {expected} element(s)", "length", assert.length);
     }
 };

--- a/test/assert-test.js
+++ b/test/assert-test.js
@@ -13,6 +13,7 @@ vows.describe('vows/assert').addBatch({
         "`lengthOf`": function () {
             assert.lengthOf("hello world", 11);
             assert.lengthOf([1, 2, 3], 3);
+            assert.lengthOf({goo: true, gies: false}, 2);
         },
         "`isDefined`": function () {
             assert.isDefined(null);


### PR DESCRIPTION
Add the possibility to do:
    assert.lengthOf({goo: true, gies: false}, 2);

Fix #139

This way lengthOf is more consistent with `isEmty` and `isNotEmpty`
