### PR TITLE
Create pending tests by prefixing your tests name or context by '// '

### DIFF
--- a/lib/vows.js
+++ b/lib/vows.js
@@ -111,7 +111,9 @@ function addVow(vow) {
     return this;
 
     function runTest(args, ctx) {
-        if (vow.callback instanceof String) {
+        if (vow.callback instanceof String
+            || vow.description.indexOf('// ') === 0
+            || vow.binding.context.title.indexOf('// ') !== -1) {
             return output('pending');
         }
 

--- a/lib/vows/suite.js
+++ b/lib/vows/suite.js
@@ -131,7 +131,8 @@ this.Suite.prototype = new(function () {
                 // Run the topic, passing the previous context topics
                 // If topic `throw`s an exception, pass it down as a value
                 try {
-                    topic = topic.apply(ctx.env, ctx.topics);
+                    if(ctx.title.indexOf('// ') === -1) 
+                      topic = topic.apply(ctx.env, ctx.topics);
                 }
                 catch (ex) {
                     topic = ex;

--- a/test/vows-test.js
+++ b/test/vows-test.js
@@ -520,3 +520,44 @@ vows.describe('Async topic is passed to vows with topic-less subcontext').addBat
         }
     }
 })['export'](module);
+
+vows.describe('Pending tests with // prefix').addBatch({
+    'Given an honorable topic': {
+        topic: function () {
+            var callback = this.callback;
+            process.nextTick(function () {
+                callback(null, 42);
+            });
+        },
+        'Then honorable vows are executed': function (topic) {
+            assert.equal(topic, 42);
+        },
+        '// and pending vows are not executed': function (topic) {
+            throw new Error('Should not be executed.');
+        },
+        '// and given a pending context': {
+            'then every sub context are pending': function (topic) {
+                throw new Error('Should not be executed.');
+            }
+        },
+        'given an honorable sub context': {
+            'then honorable vows are executed': function (topic) {
+                assert.equal(topic, 42);
+            },
+            '// and pending vows are not executed': function (topic) {
+                throw new Error('Should not be executed.');
+            }
+        },
+        '// given a pending sub context with an inner topic': {
+            topic: function (parenttopic) {
+                process.nextTick(function(){
+                  throw new Error('Should not be executed.');
+                })
+                return parenttopic + 1;
+            },
+            'then both sub-topics and sub-vows are not executed': function (topic) {
+                throw new Error('Should not be executed.');
+            }
+        }
+    }
+})['export'](module);


### PR DESCRIPTION
I am quite agree with #165, but I would prefer an other syntax : 

```
{
 '// foo': function (result) {
    assert.equal(result, 'good');
 },
```

   }

Every vow containing `//` (the space is important) will be in pending state.

Every topic under a pending context will not be executed.

```
'// given a pending sub context with an inner topic': {
  topic: function (parenttopic) {
    process.nextTick(function(){
      throw new Error('Should not be executed.');
    })
    return parenttopic + 1;
  },
  'then both sub-topics and sub-vows are not executed': function (topic) {
    throw new Error('Should not be executed.');
  }
}
```
