### PR TITLE
Expect a vow to be called n times

### DIFF
--- a/lib/vows.js
+++ b/lib/vows.js
@@ -111,6 +111,13 @@ function addVow(vow) {
     return this;
 
     function runTest(args, ctx) {
+        vow.count ++;
+
+        // We're running this test an additional time (i.e. a duplicate callback or event fired)
+        if (vow.count > 1) {
+          batch.total ++;
+        }
+
         if (vow.callback instanceof String) {
             return output('pending');
         }
@@ -129,7 +136,10 @@ function addVow(vow) {
         // Run the test, and try to catch `AssertionError`s and other exceptions;
         // increment counters accordingly.
         try {
-            vow.callback.apply(ctx === global || !ctx ? vow.binding : ctx, args);
+            var vowCtx = ctx === global || !ctx ? vow.binding : ctx;
+            vowCtx.expect = function(num){ vow.expected = num };
+
+            vow.callback.apply(vowCtx, args);
             output('honored');
         } catch (e) {
             if (e.name && e.name.match(/AssertionError/)) {
@@ -172,6 +182,7 @@ process.on('exit', function () {
         }
         s.batches.forEach(function (b) {
             var unFired = [];
+            var expected = [];
 
             b.vows.forEach(function (vow) {
                 if (! vow.status) {
@@ -179,14 +190,29 @@ process.on('exit', function () {
                         unFired.push(vow.context);
                     }
                 }
+                if (vow.expected !== -1 && vow.expected !== vow.count) {
+                    vow.status = 'broken';
+                    if (expected.indexOf(vow.context) === -1) {
+                        expected.push(vow);
+                    }
+                }
             });
 
-            if (unFired.length > 0) { util.print('\n') }
+            if (unFired.length > 0 || expected.length > 0) { util.print('\n') }
 
             unFired.forEach(function (title) {
                 s.reporter.report(['error', {
                     error: "callback not fired",
                     context: title,
+                    batch: b,
+                    suite: s
+                }]);
+            });
+
+            expected.forEach(function (vow) {
+                s.reporter.report(['error', {
+                    error: "Expected to be called " + vow.expected + " time(s) but was " + vow.count,
+                    context: vow.context + ' ' + vow.description,
                     batch: b,
                     suite: s
                 }]);

--- a/lib/vows/suite.js
+++ b/lib/vows/suite.js
@@ -208,7 +208,9 @@ this.Suite.prototype = new(function () {
                     description: item,
                     binding: ctx.env,
                     status: null,
-                    batch: batch
+                    batch: batch,
+                    expected: -1,
+                    count: 0
                 });
 
                 // If we encounter a function, add it to the callbacks

--- a/test/vows-test.js
+++ b/test/vows-test.js
@@ -520,3 +520,42 @@ vows.describe('Async topic is passed to vows with topic-less subcontext').addBat
         }
     }
 })['export'](module);
+
+
+vows.describe("Vows with events that fire mutiple times").addBatch({
+  "A context": {
+    topic: function() {
+      this.context.event = 'end';
+
+      var topic = new(events.EventEmitter);
+
+      process.nextTick(function () {
+        topic.emit('ping', 'ping_data');
+        topic.emit('ping', 'ping_data');
+        topic.emit('ping', 'ping_data');
+        topic.emit('ping', 'ping_data');
+        topic.emit('ping', 'ping_data');
+        topic.emit('ping', 'ping_data');
+      });
+
+      process.nextTick(function() {
+        topic.emit('end', 'end_data');
+      });
+
+      return topic;
+    },
+    on: {
+      "ping": {
+        "will fire with ping_data": function(data) {
+          this.expect(7);
+          assert.strictEqual(data, 'ping_data');
+        }
+      },
+      "end": {
+        "will fire will end_data": function(data) {
+          assert.strictEqual(data, 'end_data');
+        }
+      }
+    }
+  }
+}).export(module);


### PR DESCRIPTION
When testing events, it's quite common that a vow is executed multiple times.
This job is done in the pull request #193 by @bacchusrx

But it's also quite common to test how many times the vow was called.

I added the function `expect(num)` in the vow context.

```
vows.describe("Vows with events that fire mutiple times").addBatch({
  "A context": {
    topic: function() {
      this.context.event = 'end';

      var topic = new(events.EventEmitter);

      process.nextTick(function () {
        topic.emit('ping', 'ping_data');
        topic.emit('ping', 'ping_data');
      });

      process.nextTick(function() {
        topic.emit('end', 'end_data');
      });

      return topic;
    },
    on: {
      "ping": {
        "will fire with ping_data": function(data) {
          this.expect(7);
          assert.strictEqual(data, 'ping_data');
        }
      },
      "end": {
        "will fire will end_data": function(data) {
          assert.strictEqual(data, 'end_data');
        }
      }
    }
  }
}).export(module);


✗ Errored » Expected to be called 7 time(s) but was 2 
      in A context on ping will fire with ping_data 
      in Vows with events that fire mutiple times 
      in test/vows-test.js
```
