### PR TITLE
update the directive for `npm test` to be cross-platform

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,6 @@
   "bin"           : { "vows": "./bin/vows" },
   "directories"   : { "test": "./test", "bin": "./bin" },
   "version"       : "0.6.3",
-  "scripts"       : {"test": "./bin/vows --spec"},
+  "scripts"       : {"test": "node bin/vows --spec"},
   "engines"       : {"node": ">=0.2.6"}
 }


### PR DESCRIPTION
update the directive for `npm test` to be cross-platform

```
  "scripts"       : {"test": "node bin/vows --spec"},
```

instead of 

```
  "scripts"       : {"test": "./bin/vows --spec"},
```
