### PR TITLE
Ensure that assertions fail when arguments are missing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 node_modules
+
+# Intellij project files
+*.iml
+*.ipr
+*.iws

--- a/lib/assert/macros.js
+++ b/lib/assert/macros.js
@@ -17,6 +17,7 @@ for (var key in messages) {
 }
 
 assert.epsilon = function (eps, actual, expected, message) {
+    assertMissingArguments(arguments, assert.epsilon);
     if (Math.abs(actual - expected) > eps) {
         assert.fail(actual, expected, message || "expected {expected} \u00B1"+ eps +", but was {actual}");
     }
@@ -29,6 +30,7 @@ assert.ok = (function (callback) {
 })(assert.ok);
 
 assert.match = function (actual, expected, message) {
+    assertMissingArguments(arguments, assert.match);
     if (! expected.test(actual)) {
         assert.fail(actual, expected, message || "expected {actual} to match {expected}", "match", assert.match);
     }
@@ -36,38 +38,45 @@ assert.match = function (actual, expected, message) {
 assert.matches = assert.match;
 
 assert.isTrue = function (actual, message) {
+    assertMissingArguments(arguments, assert.isTrue);
     if (actual !== true) {
         assert.fail(actual, true, message || "expected {expected}, got {actual}", "===", assert.isTrue);
     }
 };
 assert.isFalse = function (actual, message) {
+    assertMissingArguments(arguments, assert.isFalse);
     if (actual !== false) {
         assert.fail(actual, false, message || "expected {expected}, got {actual}", "===", assert.isFalse);
     }
 };
 assert.isZero = function (actual, message) {
+    assertMissingArguments(arguments, assert.isZero);
     if (actual !== 0) {
         assert.fail(actual, 0, message || "expected {expected}, got {actual}", "===", assert.isZero);
     }
 };
 assert.isNotZero = function (actual, message) {
+    assertMissingArguments(arguments, assert.isNotZero);
     if (actual === 0) {
         assert.fail(actual, 0, message || "expected non-zero value, got {actual}", "===", assert.isNotZero);
     }
 };
 
 assert.greater = function (actual, expected, message) {
+    assertMissingArguments(arguments, assert.greater);
     if (actual <= expected) {
         assert.fail(actual, expected, message || "expected {actual} to be greater than {expected}", ">", assert.greater);
     }
 };
 assert.lesser = function (actual, expected, message) {
+    assertMissingArguments(arguments, assert.lesser);
     if (actual >= expected) {
         assert.fail(actual, expected, message || "expected {actual} to be lesser than {expected}", "<", assert.lesser);
     }
 };
 
 assert.inDelta = function (actual, expected, delta, message) {
+    assertMissingArguments(arguments, assert.inDelta);
     var lower = expected - delta;
     var upper = expected + delta;
     if (actual < lower || actual > upper) {
@@ -79,6 +88,7 @@ assert.inDelta = function (actual, expected, delta, message) {
 // Inclusion
 //
 assert.include = function (actual, expected, message) {
+    assertMissingArguments(arguments, assert.include);
     if ((function (obj) {
         if (isArray(obj) || isString(obj)) {
             return obj.indexOf(expected) === -1;
@@ -93,6 +103,7 @@ assert.include = function (actual, expected, message) {
 assert.includes = assert.include;
 
 assert.deepInclude = function (actual, expected, message) {
+    assertMissingArguments(arguments, assert.deepInclude);
     if (!isArray(actual)) {
         return assert.include(actual, expected, message);
     }
@@ -106,17 +117,20 @@ assert.deepIncludes = assert.deepInclude;
 // Length
 //
 assert.isEmpty = function (actual, message) {
+    assertMissingArguments(arguments, assert.isEmpty);
     if ((isObject(actual) && Object.keys(actual).length > 0) || actual.length > 0) {
         assert.fail(actual, 0, message || "expected {actual} to be empty", "length", assert.isEmpty);
     }
 };
 assert.isNotEmpty = function (actual, message) {
+    assertMissingArguments(arguments, assert.isNotEmpty);
     if ((isObject(actual) && Object.keys(actual).length === 0) || actual.length === 0) {
         assert.fail(actual, 0, message || "expected {actual} to be not empty", "length", assert.isNotEmpty);
     }
 };
 
 assert.lengthOf = function (actual, expected, message) {
+    assertMissingArguments(arguments, assert.lengthOf);
     var len = isObject(actual) ? Object.keys(actual).length : actual.length;
     if (len !== expected) {
         assert.fail(actual, expected, message || "expected {actual} to have {expected} element(s)", "length", assert.length);
@@ -127,12 +141,15 @@ assert.lengthOf = function (actual, expected, message) {
 // Type
 //
 assert.isArray = function (actual, message) {
+    assertMissingArguments(arguments, assert.isArray);
     assertTypeOf(actual, 'array', message || "expected {actual} to be an Array", assert.isArray);
 };
 assert.isObject = function (actual, message) {
+    assertMissingArguments(arguments, assert.isObject);
     assertTypeOf(actual, 'object', message || "expected {actual} to be an Object", assert.isObject);
 };
 assert.isNumber = function (actual, message) {
+    assertMissingArguments(arguments, assert.isNumber);
     if (isNaN(actual)) {
         assert.fail(actual, 'number', message || "expected {actual} to be of type {expected}", "isNaN", assert.isNumber);
     } else {
@@ -140,42 +157,51 @@ assert.isNumber = function (actual, message) {
     }
 };
 assert.isBoolean = function (actual, message) {
+    assertMissingArguments(arguments, assert.isBoolean);
     if (actual !== true && actual !== false) {
         assert.fail(actual, 'boolean', message || "expected {actual} to be a Boolean", "===", assert.isBoolean);
     }
 };
 assert.isNaN = function (actual, message) {
+    assertMissingArguments(arguments, assert.isNaN);
     if (actual === actual) {
         assert.fail(actual, 'NaN', message || "expected {actual} to be NaN", "===", assert.isNaN);
     }
 };
 assert.isNull = function (actual, message) {
+    assertMissingArguments(arguments, assert.isNull);
     if (actual !== null) {
         assert.fail(actual, null, message || "expected {expected}, got {actual}", "===", assert.isNull);
     }
 };
 assert.isNotNull = function (actual, message) {
+    assertMissingArguments(arguments, assert.isNotNull);
     if (actual === null) {
         assert.fail(actual, null, message || "expected non-null value, got {actual}", "===", assert.isNotNull);
     }
 };
 assert.isUndefined = function (actual, message) {
+    assertMissingArguments(arguments, assert.isUndefined);
     if (actual !== undefined) {
         assert.fail(actual, undefined, message || "expected {actual} to be {expected}", "===", assert.isUndefined);
     }
 };
 assert.isDefined = function (actual, message) {
+    assertMissingArguments(arguments, assert.isDefined);
     if(actual === undefined) {
         assert.fail(actual, 0, message || "expected {actual} to be defined", "===", assert.isDefined);
     }
 };
 assert.isString = function (actual, message) {
+    assertMissingArguments(arguments, assert.isString);
     assertTypeOf(actual, 'string', message || "expected {actual} to be a String", assert.isString);
 };
 assert.isFunction = function (actual, message) {
+    assertMissingArguments(arguments, assert.isFunction);
     assertTypeOf(actual, 'function', message || "expected {actual} to be a Function", assert.isFunction);
 };
 assert.typeOf = function (actual, expected, message) {
+    assertMissingArguments(arguments, assert.typeOf);
     assertTypeOf(actual, expected, message, assert.typeOf);
 };
 assert.instanceOf = function (actual, expected, message) {
@@ -188,11 +214,17 @@ assert.instanceOf = function (actual, expected, message) {
 // Utility functions
 //
 
+function assertMissingArguments(args, caller) {
+    if (args.length === 0) {
+        assert.fail("", "", "expected number of arguments to be greater than zero", "", caller);
+    }
+}
+
 function assertTypeOf(actual, expected, message, caller) {
     if (typeOf(actual) !== expected) {
         assert.fail(actual, expected, message || "expected {actual} to be of type {expected}", "typeOf", caller);
     }
-};
+}
 
 function isArray (obj) {
     return Array.isArray(obj);

--- a/test/assert-test.js
+++ b/test/assert-test.js
@@ -8,31 +8,38 @@ vows.describe('vows/assert').addBatch({
             assert.equal(1, true);
         },
         "`epsilon`": function() {
+            assertNoArguments(assert.epsilon);
             assert.epsilon(1e-5, 0.1+0.2, 0.3);
         },
         "`match`": function () {
+            assertNoArguments(assert.match);
             assert.match("hello world", /^[a-z]+ [a-z]+$/);
         },
         "`lengthOf`": function () {
+            assertNoArguments(assert.lengthOf);
             assert.lengthOf("hello world", 11);
             assert.lengthOf([1, 2, 3], 3);
             assert.lengthOf({goo: true, gies: false}, 2);
         },
         "`isDefined`": function () {
+            assertNoArguments(assert.isDefined);
             assert.isDefined(null);
             assertError(assert.isDefined, undefined);
         },
         "`include`": function () {
+            assertNoArguments(assert.include);
             assert.include("hello world", "world");
             assert.include([0, 42, 0],    42);
             assert.include({goo:true},    'goo');
         },
         "`deepInclude`": function () {
+            assertNoArguments(assert.deepInclude);
             assert.deepInclude([{a:'b'},{c:'d'}], {a:'b'});
             assert.deepInclude("hello world", "world");
             assert.deepInclude({goo:true},    'goo');
         },
         "`typeOf`": function () {
+            assertNoArguments(assert.typeOf);
             assert.typeOf('goo', 'string');
             assert.typeOf(42,    'number');
             assert.typeOf([],    'array');
@@ -40,67 +47,80 @@ vows.describe('vows/assert').addBatch({
             assert.typeOf(false, 'boolean');
         },
         "`instanceOf`": function () {
+            assertNoArguments(assert.instanceOf);
             assert.instanceOf([], Array);
             assert.instanceOf(function () {}, Function);
         },
         "`isArray`": function () {
+            assertNoArguments(assert.isArray);
             assert.isArray([]);
             assertError(assert.isArray, {});
         },
         "`isString`": function () {
+            assertNoArguments(assert.isString);
             assert.isString("");
         },
         "`isObject`": function () {
+            assertNoArguments(assert.isObject);
             assert.isObject({});
             assertError(assert.isObject, []);
         },
         "`isNumber`": function () {
+            assertNoArguments(assert.isNumber);
             assert.isNumber(0);
         },
         "`isBoolean`": function (){
+            assertNoArguments(assert.isBoolean);
             assert.isBoolean(true);
             assert.isBoolean(false);
             assertError(assert.isBoolean, 0);
         },
         "`isNan`": function () {
+            assertNoArguments(assert.isNaN);
             assert.isNaN(0/0);
         },
         "`isTrue`": function () {
+            assertNoArguments(assert.isTrue);
             assert.isTrue(true);
             assertError(assert.isTrue, 1);
         },
         "`isFalse`": function () {
+            assertNoArguments(assert.isFalse);
             assert.isFalse(false);
             assertError(assert.isFalse, 0);
         },
         "`isZero`": function () {
+            assertNoArguments(assert.isZero);
             assert.isZero(0);
             assertError(assert.isZero, null);
         },
         "`isNotZero`": function () {
+            assertNoArguments(assert.isNotZero);
             assert.isNotZero(1);
         },
         "`isUndefined`": function () {
+            assertNoArguments(assert.isUndefined);
             assert.isUndefined(undefined);
             assertError(assert.isUndefined, null);
         },
-        "`isDefined`": function () {
-            assert.isDefined(null);
-            assertError(assert.isDefined, undefined);
-        },
         "`isNull`": function () {
+            assertNoArguments(assert.isNull);
             assert.isNull(null);
             assertError(assert.isNull, 0);
             assertError(assert.isNull, undefined);
         },
         "`isNotNull`": function () {
+            assertNoArguments(assert.isNotNull);
             assert.isNotNull(0);
         },
         "`greater` and `lesser`": function () {
+            assertNoArguments(assert.greater);
+            assertNoArguments(assert.lesser);
             assert.greater(5, 4);
             assert.lesser(4, 5);
         },
         "`inDelta`": function () {
+            assertNoArguments(assert.inDelta);
             assert.inDelta(42, 40, 5);
             assert.inDelta(42, 40, 2);
             assert.inDelta(42, 42, 0);
@@ -108,11 +128,13 @@ vows.describe('vows/assert').addBatch({
             assertError(assert.inDelta, [42, 40, 1]);
         },
         "`isEmpty`": function () {
+            assertNoArguments(assert.isEmpty);
             assert.isEmpty({});
             assert.isEmpty([]);
             assert.isEmpty("");
         },
         "`isNotEmpty`": function () {
+            assertNoArguments(assert.isNotEmpty);
             assert.isNotEmpty({goo:true});
             assert.isNotEmpty([1]);
             assert.isNotEmpty(" ");
@@ -135,3 +157,15 @@ function assertError(assertion, args, fail) {
                                "assertError", assertError);
 }
 
+function assertNoArguments(assertion) {
+    var fail;
+    try {
+        assertion.apply(null, []);
+        fail = true;
+
+    } catch (e) {/* Success */}
+
+    fail && assert.fail("", assert.AssertionError,
+                               "expected an AssertionError for missing argument(s)",
+                               "assertError", assertError);
+}


### PR DESCRIPTION
- Ensure that all assertions defined in macros.js throw an
  AssertionException when they are called with no arguments
- Removing duplicate `isDefined` test
- Adding IDEA project files to .gitignore
