### PR TITLE
Round coverage percentage down.

### DIFF
--- a/lib/vows/coverage/report-html.js
+++ b/lib/vows/coverage/report-html.js
@@ -70,7 +70,7 @@ this.report = function (coverageMap) {
         }
     }
 
-    summary.coverage = (summary.hits / summary.sloc) * 100;
+    summary.coverage = Math.floor((summary.hits / summary.sloc) * 100);
 
     fs.writeSync(out, '<h1 id="overview">Coverage</h1><div id="menu">');
 


### PR DESCRIPTION
The HTML coverage reporter can show coverage less than 100% as "100".
This patch will round fractional values down to avoid confusion.
For example:

```
((275/276) * 100).toFixed(0) == "100"
```

vs

```
Math.floor((275/276) * 100).toFixed(0) == "99"
```
