### PR TITLE
Changed Makefile's test command to ignore 'fixtures' directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,6 @@
 # Run all tests
 #
 test: 
-	@@bin/vows test/*
+	@@bin/vows test/*.js
 
 .PHONY: test install


### PR DESCRIPTION
Changed Makefile's test command to ignore 'fixtures' directory because it was throwing an error.
