### PR TITLE
Diff colors are reversed from labels

### DIFF
--- a/lib/assert/error.js
+++ b/lib/assert/error.js
@@ -67,7 +67,7 @@ function styleLines(str, name) {
  */
 
 function errorDiff(err, type) {
-  return diff['diff' + type](err.actual, err.expected).map(function(str){
+  return diff['diff' + type](err.expected, err.actual).map(function(str){
     if (/^(\n+)$/.test(str.value)) str.value = Array(++RegExp.$1.length).join('<newline>');
     if (str.added) return styleLines(str.value, 'green');
     if (str.removed) return styleLines(str.value, 'red');


### PR DESCRIPTION
Given the following test:

``` js
var  vows = require('vows')
    ,assert = require('assert');

vows.describe('something').addBatch({
    'actual vs expected': {

        'should be colored correctly': function (topic) {
            assert.equal('this is the actual', 'this is the expected')
        }
    }
}).run()
```

I get the following screenshot:

![reversed](http://i.imgur.com/v0jgv.png)

This pull request makes it instead look like:

![proper](http://i.imgur.com/l6x53.png)
