### PR TITLE
Move broken/errored events display to the end of spec report.

### DIFF
--- a/lib/vows/reporters/spec.js
+++ b/lib/vows/reporters/spec.js
@@ -4,7 +4,8 @@ var options = { tail: '\n' };
 var console = require('../../vows/console');
 var stylize = console.stylize,
     puts = console.puts(options),
-    summary = {};
+    summary = {},
+    currSubject;
 //
 // Console reporter
 //
@@ -18,6 +19,7 @@ this.report = function (data) {
 
     switch (data[0]) {
         case 'subject':
+            currSubject = event;
             puts('\n♢ ' + stylize(event, 'bold') + '\n');
             break;
         case 'context':
@@ -26,10 +28,13 @@ this.report = function (data) {
         case 'vow':
             if (event.status === 'broken' || event.status === 'errored') {
                 var context = event.context;
-                if (summary[context]) {
-                    summary[context].push(event);
+                if (!summary[currSubject]) {
+                    summary[currSubject] = {};
+                    summary[currSubject][context] = [event];
+                } else if (!summary[currSubject][context]) {
+                    summary[currSubject][context] = [event];
                 } else {
-                    summary[context] = [event];
+                    summary[currSubject][context].push(event);
                 }
             } else {
                 puts(console.vowText(event));
@@ -39,10 +44,13 @@ this.report = function (data) {
             util.print('\n');
             break;
         case 'finish':
-            Object.keys(summary).forEach(function (context) {
-                puts(console.contextText(context));
-                summary[context].forEach(function (event) {
-                    puts(console.vowText(event));
+            Object.keys(summary).forEach(function (subject) {
+                puts('\n♢ ' + stylize(subject, 'bold') + '\n');
+                Object.keys(summary[subject]).forEach(function (context) {
+                    puts(console.contextText(context));
+                    summary[subject][context].forEach(function (event) {
+                        puts(console.vowText(event));
+                    });
                 });
             });
             puts(console.result(event).join('\n'));


### PR DESCRIPTION
Finding broken/errored tests among a large number of tests is time consuming, almost impossible when there are hundreds of tests and the few errors are buried in between.

This pull request displays those errors at the end of the spec reporter output, making it easy to find the errors, fix, run the test again, the next error (if any) is at the end of the output again.
