### PR TITLE
Cryptic Asynchronous Error Message

### DIFF
--- a/lib/vows.js
+++ b/lib/vows.js
@@ -171,26 +171,22 @@ process.on('exit', function () {
             s.reporter.report(['error', { error: "Asynchronous Error", suite: s }]);
         }
         s.batches.forEach(function (b) {
-            var unFired = [];
+            
+            // Check for any contexts that are still waiting for their
+            // callbacks to trigger.
+            if (typeof(b._callbackPending) !== 'undefined') {
+                b._callbackPending.forEach(function (pending) {
+                    
+                    util.print('\n  ')
 
-            b.vows.forEach(function (vow) {
-                if (! vow.status) {
-                    if (unFired.indexOf(vow.context) === -1) {
-                        unFired.push(vow.context);
-                    }
-                }
-            });
-
-            if (unFired.length > 0) { util.print('\n') }
-
-            unFired.forEach(function (title) {
-                s.reporter.report(['error', {
-                    error: "callback not fired",
-                    context: title,
-                    batch: b,
-                    suite: s
-                }]);
-            });
+                    s.reporter.report(['error', {
+                        error: "callback not fired",
+                        context: pending.name,
+                        batch: b,
+                        suite: s
+                    }]);
+                });
+            }
 
             if (b.status === 'begin') {
                 failure = true;

--- a/lib/vows/suite.js
+++ b/lib/vows/suite.js
@@ -111,6 +111,8 @@ this.Suite.prototype = new(function () {
 
         batch.status = 'begin';
 
+        batch._callbackPending = [];
+
         // The test runner, it calls itself recursively, passing the
         // previous context to the inner contexts. This is so the `topic`
         // functions have access to all the previous context topics in their
@@ -178,6 +180,21 @@ this.Suite.prototype = new(function () {
                           topic = ctx.emitter;
                       }
                 }
+            }
+
+            // If the function has a callback, add it to a
+            // array so we can keep track of what callbacks fired.
+            // When the callback fires, we can clear the item from the array.
+            if (ctx._callback) {
+
+                batch._callbackPending.push(ctx);
+                
+                var callbackDone = function() {
+                    batch._callbackPending.splice(batch._callbackPending.indexOf(ctx), 1);  
+                }
+
+                topic.on('success', callbackDone);
+                topic.on('error', callbackDone);
             }
 
             topic.on(ctx.event, function (val) {


### PR DESCRIPTION
If a callback with a nested context never triggered the script will throw an "Asynchronous Error" without any further detail about the test that potentially failed. If a callback fails on a normal test without a nested context, the script returns a "callback not fired" error with some more info. This is very helpful for debugging, so I have added the functionality to keep track of callbacks that haven't fired yet and report on them at the end of execution.

Related to issue reported: https://github.com/cloudhead/vows/issues/125
