### PR TITLE
make importSuites work with jscover

### DIFF
--- a/bin/vows
+++ b/bin/vows
@@ -570,10 +570,12 @@ function importSuites(files) {
     } : function (suites, f) {
         //f = path.join(process.cwd(), path.relative(process.cwd(),f));
         var obj = require(f);
-        return suites.concat(Object.keys(obj).map(function (s) {
-            obj[s]._filename = cwdname(f);
-            return obj[s];
-        }));
+        return suites.concat(
+            Object.keys(obj).filter(function(s) { return s !== '_$jscoverage'; }).map(function (s) {
+                obj[s]._filename = cwdname(f);
+                return obj[s];
+            })
+        );
     }, [])
 }
 


### PR DESCRIPTION
jscover, unlike jscoverage puts another entry into the suites export which causes the suit run to fail.

This pull request just filters the '_$jscover' key from the export, making vows work with the
latest version of jscover.
