### PR TITLE
Add a repository property to package.json to avoid a warning from npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,5 +10,6 @@
   "bin"           : {"vows": "./bin/vows"},
   "directories"   : {"test": "./test", "bin": "./bin"},
   "version"       : "0.7.0",
+  "repository"    : {"type": "git", "url": "https://github.com/cloudhead/vows.git"},
   "scripts"       : {"test": "node ./bin/vows --spec"}
 }


### PR DESCRIPTION
npm gives me a warning at install time:

```
npm WARN package.json vows@0.7.0 No repository field.
```

It's harmless, but I figure it couldn't hurt to fix it.
