### PR TITLE
Make coffeescript register itself if it has a register function.

### DIFF
--- a/bin/vows
+++ b/bin/vows
@@ -16,6 +16,7 @@ var fileExt, specFileExt;
 
 try {
     var coffee = require('coffee-script');
+    if(coffee.register) coffee.register();
     fileExt     = /\.(js|coffee)$/;
     specFileExt = /[.(-|_)]((t|T)est|(s|S)pec)\.(js|coffee)$/;
 } catch (_) {


### PR DESCRIPTION
Fixes issue https://github.com/cloudhead/vows/issues/296.
