### PR TITLE
Use 'raw' mode for stylize in 'spec' reporter

### DIFF
--- a/lib/vows/reporters/spec.js
+++ b/lib/vows/reporters/spec.js
@@ -1,6 +1,6 @@
 var util = require('util');
 
-var options = { tail: '\n' };
+var options = { tail: '\n', raw: true };
 var console = require('../../vows/console');
 var stylize = console.stylize,
     puts = console.puts(options);


### PR DESCRIPTION
Hello. _Vows_ is one of the most beautiful testing systems I've ever used! :smiley:

However I've got confused a little bit by _spec_ reporter's output when I added some 'special characters', like "*****", to my topic title.
So I decided to use stylize's _'raw'_ mode for _spec_ reporter as well.
Things like `stylize(event, 'bold')` will still work. However users won't get confused when they have some special characters like "**`**" or "*****" in their vows title.
Example: `first item's number matches regexp: /^\\d[\\d.]*\\.\\d*$/`
Thank you very much.
