### PR TITLE
Add `this.callback` alternative w/o error argument

### DIFF
--- a/lib/vows/context.js
+++ b/lib/vows/context.js
@@ -5,39 +5,44 @@ this.Context = function (vow, ctx, env) {
     this.tests = vow.callback;
     this.topics = (ctx.topics || []).slice(0);
     this.emitter = null;
+    
     this.env = env || {};
     this.env.context = this;
-
-    this.env.callback = function (/* arguments */) {
-        var ctx = this;
-        var args = Array.prototype.slice.call(arguments);
-
-        var emit = (function (args) {
-            //
-            // Convert callback-style results into events.
-            //
-            if (vow.batch.suite.options.error) {
-                return function () {
-                    var e = args.shift();
-                    that.emitter.ctx = ctx;
-                    // We handle a special case, where the first argument is a
-                    // boolean, in which case we treat it as a result, and not
-                    // an error. This is useful for `path.exists` and other
-                    // functions like it, which only pass a single boolean
-                    // parameter instead of the more common (error, result) pair.
-                    if (typeof(e) === 'boolean' && args.length === 0) {
-                        that.emitter.emit.call(that.emitter, 'success', e);
-                    } else {
-                        if (e) { that.emitter.emit.apply(that.emitter, ['error', e].concat(args)) }
-                        else   { that.emitter.emit.apply(that.emitter, ['success'].concat(args)) }
-                    }
-                };
-            } else {
-                return function () {
-                    that.emitter.ctx = ctx;
-                    that.emitter.emit.apply(that.emitter, ['success'].concat(args));
-                };
-            }
+    this.env.callback = makeCallback(true);
+    this.env.callbackWithoutError = makeCallback(false);
+    
+    function makeCallback(withError) {
+        return function (/* arguments */) {
+            var ctx = this;
+            var args = Array.prototype.slice.call(arguments);
+    
+            var emit = (function (args) {
+                //
+                // Convert callback-style results into events.
+                //
+                if (withError && vow.batch.suite.options.error) {
+                    return function () {
+                        var e = args.shift();
+                        that.emitter.ctx = ctx;
+                        // We handle a special case, where the first argument is a
+                        // boolean, in which case we treat it as a result, and not
+                        // an error. This is useful for `path.exists` and other
+                        // functions like it, which only pass a single boolean
+                        // parameter instead of the more common (error, result) pair.
+                        if (typeof(e) === 'boolean' && args.length === 0) {
+                            that.emitter.emit.call(that.emitter, 'success', e);
+                        } else {
+                            if (e) { that.emitter.emit.apply(that.emitter, ['error', e].concat(args)) }
+                            else   { that.emitter.emit.apply(that.emitter, ['success'].concat(args)) }
+                        }
+                    };
+                } else {
+                    return function () {
+                        that.emitter.ctx = ctx;
+                        that.emitter.emit.apply(that.emitter, ['success'].concat(args));
+                    };
+                }
+            };
         })(args.slice(0));
         // If `this.callback` is called synchronously,
         // the emitter will not have been set yet,
@@ -46,6 +51,7 @@ this.Context = function (vow, ctx, env) {
         if (that.emitter) { emit() }
         else              { process.nextTick(emit) }
     };
+    
     this.name = vow.description;
     // events is an alias for on
     if (this.name === 'events') {

--- a/lib/vows/context.js
+++ b/lib/vows/context.js
@@ -42,14 +42,15 @@ this.Context = function (vow, ctx, env) {
                         that.emitter.emit.apply(that.emitter, ['success'].concat(args));
                     };
                 }
-            };
-        })(args.slice(0));
-        // If `this.callback` is called synchronously,
-        // the emitter will not have been set yet,
-        // so we defer the emition, that way it'll behave
-        // asynchronously.
-        if (that.emitter) { emit() }
-        else              { process.nextTick(emit) }
+            })(args.slice(0));
+            
+            // If `this.callback` is called synchronously,
+            // the emitter will not have been set yet,
+            // so we defer the emition, that way it'll behave
+            // asynchronously.
+            if (that.emitter) { emit() }
+            else              { process.nextTick(emit) }
+        };
     };
     
     this.name = vow.description;

--- a/test/callback-without-errors-test.js
+++ b/test/callback-without-errors-test.js
@@ -4,7 +4,7 @@ var vows = require('../lib/vows'),
 var getFirstWord = function (str, callback) {
     callback(str.split(' ')[0]);
 };
-vows.describe('Example use-case').addBatch({
+vows.describe('Using this.callbackWithoutError inside a topic').addBatch({
     'Calling getFirstWord with "hello world!"': {
         topic: function () {
             return getFirstWord('hello world!', this.callbackWithoutError);

--- a/test/callback-without-errors-test.js
+++ b/test/callback-without-errors-test.js
@@ -1,0 +1,16 @@
+var vows = require('../lib/vows'),
+    assert = require('assert');
+
+var getFirstWord = function (str, callback) {
+    callback(str.split(' ')[0]);
+};
+vows.describe('Example use-case').addBatch({
+    'Calling getFirstWord with "hello world!"': {
+        topic: function () {
+            return getFirstWord('hello world!', this.callbackWithoutError);
+        },
+        'should result in "hello"': function (result) {
+            assert.equal('hello', result);
+        }
+    }
+}).export(module);


### PR DESCRIPTION
Added a function `this.callbackWithoutError` in addition to `this.callback`. This will be used on a case-by-case basis when `topic` is asynchronous and result callback doesn't pass error as first parameter, instead passing the result (to be passed to a vow).
