### PR TITLE
Delay process.exit for proper drain of streams on node 0.10

### DIFF
--- a/bin/vows
+++ b/bin/vows
@@ -305,13 +305,11 @@ if (! options.watch) {
         } catch (err) {
             // ignore the undefined jscoverage
         }
-        if (process.stdout.write('')) { // Check if stdout is drained
-            process.exit(status);
-        } else {
-            process.stdout.on('drain', function () {
+        process.on('exit', function (code) {
+            if (code === 0) {
                 process.exit(status);
-            });
-        }
+            }
+        });
     });
 } else {
     //


### PR DESCRIPTION
This fixes #273 - it was eating "finish" output from child process - and it was treating like failure
