### PR TITLE
Adding exception when the batch is unhandled

### DIFF
--- a/lib/vows/suite.js
+++ b/lib/vows/suite.js
@@ -387,6 +387,8 @@ this.tryEnd = function (batch) {
             batch.status = 'end';
             batch.suite.report(['end']);
             batch.promise.emit('end', batch.honored, batch.broken, batch.errored, batch.pending);
+        } else {
+            throw new Error("Batch tryEnd was unhandled");
         }
     }
 };


### PR DESCRIPTION
Hi,

I've found an issue using vows under api-easy.  Regularly I get an error like the following - below is an example that will obviously fail as google doesn't have a /login.  However when running the tryEnd function this case is unhandled and we end up with a stack overflow.

I've added a simple throw on unhandled and this allows me to retry my test if required.

```
[17:18:36] Caught exception: RangeError: Maximum call stack size exceeded

? Errored » callback not fired
      in When doing a smoke test on google.com A POST to /login
      in api smoke test for google.com
      in undefined? Errored » 1 errored  2 dropped
```
