### PR TITLE
Correct assignment for assert.notInclude() synonym assert.notIncludes()

### DIFF
--- a/lib/assert/macros.js
+++ b/lib/assert/macros.js
@@ -104,7 +104,7 @@ assert.notInclude = function (actual, expected, message) {
         assert.fail(actual, expected, message || "expected {actual} not to include {expected}", "include", assert.notInclude);
     }
 };
-assert.notIncludes = assert.notIncludes;
+assert.notIncludes = assert.notInclude;
 
 assert.deepInclude = function (actual, expected, message) {
     if (!isArray(actual)) {

--- a/test/assert-test.js
+++ b/test/assert-test.js
@@ -119,6 +119,10 @@ vows.describe('vows/assert').addBatch({
             assertError(assert.isNotEmpty, {});
             assertError(assert.isNotEmpty, []);
             assertError(assert.isNotEmpty, "");
+        },
+        "`notIncludes`": function () {
+            assert.notIncludes([1, 2, 3], 4);
+            assert.notIncludes({"red": 1, "blue": 2}, "green");
         }
     }
 }).export(module);
@@ -134,4 +138,3 @@ function assertError(assertion, args, fail) {
                                "expected an AssertionError for {actual}",
                                "assertError", assertError);
 }
-


### PR DESCRIPTION
In reviewing the diffs from 0.7.0 to 0.8.0 I saw that the synonym
"notIncludes" had been added and was assigned to itself (which makes
it undefined).

This patch adds a unit test to make sure that the notIncludes synonym
exists and works correctly, and fixes the assignment.
