### PR TITLE
Make assert.epsilon fail for NaN actual value

### DIFF
--- a/lib/assert/macros.js
+++ b/lib/assert/macros.js
@@ -17,7 +17,9 @@ for (var key in messages) {
 }
 
 assert.epsilon = function (eps, actual, expected, message) {
-    if (isNaN(actual) || Math.abs(actual - expected) > eps) {
+    if (isNaN(eps)) {
+        assert.fail(actual, expected, message || "cannot compare {actual} with {expected} \u00B1 NaN");
+    } else if (isNaN(actual) || Math.abs(actual - expected) > eps) {
         assert.fail(actual, expected, message || "expected {expected} \u00B1"+ eps +", but was {actual}");
     }
 };

--- a/test/assert-test.js
+++ b/test/assert-test.js
@@ -9,6 +9,12 @@ vows.describe('vows/assert').addBatch({
         },
         "`epsilon`": function() {
             assert.epsilon(1e-5, 0.1+0.2, 0.3);
+            assert.throws(function() {
+              assert.epsilon(1e-5, NaN, 0.3);
+            });
+            assert.throws(function() {
+              assert.epsilon(NaN, 1.0, 1.0);
+            });
         },
         "`match`": function () {
             assert.match("hello world", /^[a-z]+ [a-z]+$/);


### PR DESCRIPTION
It makes sense than NaN would not be within a tolerance of a number. but
since Math.abs(NaN) = NaN and NaN > x evalutes to false for all numeric
x, assert.epsilon will pass if NaN is passed as the 'actual' argument.

I could not determine how to use vows to assert that an assertion would
fail, so there is no test case for this change, but the existing tests
pass. I'm not sure asserting that an assertion will fail is possible
with the library's promise-oriented design.

This bug was originally found while working on the jStat project which
relies on vows; if the vows team does not want to make assert.epsilon
fail for NaN actual value, it would be good to have an additional method
that would check both that the argument is a number and within the
tolerance.
