### PR TITLE
Fix for #345

### DIFF
--- a/test/fixtures/isolate/passing.coffee
+++ b/test/fixtures/isolate/passing.coffee
@@ -2,12 +2,39 @@ vows = require '../../../lib/vows'
 
 assert = require 'assert'
 
-obvious = null
-vows.describe 'passing'
+# accommodate for pre 1.7.x coffee-script
+# first try new notation rules
+try
 
-    .addBatch
+    vows.describe 'passing'
 
-        'Obvious test': obvious =
+        .addBatch
+
+            'Obvious test': obvious =
+
+                topic: ->
+
+                    @callback null, true
+
+                'should work': (result) ->
+
+                    assert.ok result
+
+            'Obvious test #2': obvious
+
+            'Obvious test #3': obvious
+
+            'Obvious test #4': obvious
+
+        .export module
+
+catch e
+
+# fall back to old notation rules
+
+    vows.describe('passing').addBatch({
+
+        'Obvious test': obvious = 
 
             topic: ->
 
@@ -23,5 +50,5 @@ vows.describe 'passing'
 
         'Obvious test #4': obvious
 
-    .export module
+    }).export module
 


### PR DESCRIPTION
- fixes #345: isolate coffee tests must not fail with older versions of coffee-script