### PR TITLE
Add promise support

### DIFF
--- a/lib/vows/suite.js
+++ b/lib/vows/suite.js
@@ -157,6 +157,15 @@ this.Suite.prototype = new(function () {
                 }
 
                 if (typeof(topic) === 'undefined') { ctx._callback = true }
+                // Support promises returned from topic function
+                else if (typeof(topic.then) === 'function') {
+                  ctx._callback = true;
+                  topic.then(function (result) {
+                    ctx.env.callback(null, result);
+                  }, function (err) {
+                    ctx.env.callback(err);
+                  });
+                }
             }
 
             // If this context has a topic, store it in `lastTopic`,

--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
     "glob": "~4.3.1"
   },
   "devDependencies": {
-    "coffee-script": ">=1.0.0"
+    "coffee-script": ">=1.0.0",
+    "pify": "^2.3.0",
+    "promise": "^7.1.1"
   },
   "main": "./lib/vows",
   "repository": {


### PR DESCRIPTION
Allow returning Promises from topic functions. This allows defining them using the new async method syntax and it looks really nice.

``` js
vows.describe('Database').addBatch({
  'after querying "foo"': {
    async topic() {
      const db = await Database.login('login', 'passwd')
      return await db.get('foo')
    },
    'it equals "bar"': topic => {
      assert.equal(topic, "bar")
    }
  }
})
```

I made it look for the `then` method on the return value so it might break some backwards compatibility if the topic is actually an object with a `then` method but not a promise.
