### PR TITLE
Upgrade dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "Jerry Sievert <jerry@legitimatesounding.com>"
   ],
   "dependencies": {
+    "diff": "^2.2.2",
     "eyes": "~0.1.6",
-    "diff": "~1.2.0",
     "glob": "^7.0.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "eyes": "~0.1.6",
     "diff": "~1.2.0",
-    "glob": "~4.3.1"
+    "glob": "^7.0.3"
   },
   "devDependencies": {
     "coffee-script": ">=1.0.0"


### PR DESCRIPTION
This just bumps the major versions of `glob` and `diff`. I ran tests after both of these changes, and they passed both times.

Note that this PR is **required** for Vows to run on Node 7.0! Otherwise, the version of `glob` in use depends on `graceful-fs@3` which will _fail_ on Node 7.0.
