### PR TITLE
Don't assume obj.__proto__ === Object in assertion helpers

### DIFF
--- a/lib/assert/macros.js
+++ b/lib/assert/macros.js
@@ -94,10 +94,10 @@ assert.isEnumerable = function (obj, key, message) {
     assertMissingArguments(arguments, assert.isEnumerable);
     assertAnyTypeOf(obj, ["function", "object"], null, assert.isEnumerable);
     assertTypeOf(key, "string", null, assert.isEnumerable);
-    if (!obj.hasOwnProperty(key)) {
+    if (!Object.prototype.hasOwnProperty.call(obj, key)) {
         assert.fail(null, null, "key was never defined.", "isEnumerable", assert.isEnumerable);
     }
-    if (!obj.propertyIsEnumerable(key)) {
+    if (!Object.prototype.propertyIsEnumerable.call(obj, key)) {
         assert.fail(null, null, message || "expected key '" + key + "' to be enumerable", "isEnumerable", assert.isEnumerable);
     }
 };
@@ -106,10 +106,10 @@ assert.isNotEnumerable = function (obj, key, message) {
     assertMissingArguments(arguments, assert.isNotEnumerable);
     assertAnyTypeOf(obj, ["function", "object"], null, assert.isNotEnumerable);
     assertTypeOf(key, "string", null, assert.isNotEnumerable);
-    if (!obj.hasOwnProperty(key)) {
+    if (!Object.prototype.hasOwnProperty.call(obj, key)) {
         assert.fail(null, null, "key was never defined.", "isNotEnumerable", assert.isNotEnumerable);
     }
-    if (obj.propertyIsEnumerable(key)) {
+    if (Object.prototype.propertyIsEnumerable.call(obj, key)) {
         return assert.fail(null, null, message || "expected key '" + key + "' to not be enumerable", "isNotEnumerable", assert.isNotEnumerable);
     }
 };

--- a/lib/assert/macros.js
+++ b/lib/assert/macros.js
@@ -110,7 +110,7 @@ assert.isNotEnumerable = function (obj, key, message) {
         assert.fail(null, null, "key was never defined.", "isNotEnumerable", assert.isNotEnumerable);
     }
     if (Object.prototype.propertyIsEnumerable.call(obj, key)) {
-        return assert.fail(null, null, message || "expected key '" + key + "' to not be enumerable", "isNotEnumerable", assert.isNotEnumerable);
+        assert.fail(null, null, message || "expected key '" + key + "' to not be enumerable", "isNotEnumerable", assert.isNotEnumerable);
     }
 };
 


### PR DESCRIPTION
See the commit message of 53c0c36d50314fb9b6c447d44ccd8f55cae3c873 for a detailed explanation.

I also included an unrelated minor fix in the same region of code - didn't seem worth bothering with a separate PR.