### PR TITLE
chore: Update diff in 0.8.x branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "Jerry Sievert <jerry@legitimatesounding.com>"
   ],
   "dependencies": {
-    "diff": "~1.0.8",
+    "diff": "^4.0.1",
     "eyes": "~0.1.6",
     "glob": "^7.1.2"
   },


### PR DESCRIPTION
The dependency "diff" has a regexp denial-of-service vulnerability in
old versions. This updates to the current release.

(Would be great to get a 0.8.3 release out with this update!)