### PR TITLE
Remove appending cwd to the test file path

### DIFF
--- a/bin/vows.js
+++ b/bin/vows.js
@@ -41,8 +41,7 @@ let successes = 0
 let failures = 0
 
 const runTestSuite = (testFileName, callback) => {
-  const testPath = path.join(cwd, testFileName)
-  const runner = require(testPath)
+  const runner = require(testFileName)
   if (!_.isFunction(runner)) {
     callback(new Error(`Path ${testFileName} does not return a function`))
   } else {


### PR DESCRIPTION
If we assign an absolute path as the test file, the `path.join` breaks it. It's better to leave the control of the file path to the users.

@strugee please review, thanks.