### PR TITLE
Handle objects with null prototypes as topics

### DIFF
--- a/lib/batch.js
+++ b/lib/batch.js
@@ -18,6 +18,8 @@
 
 'use strict'
 
+const util = require('node:util');
+
 const _ = require('lodash')
 const async = require('async')
 const debug = require('debug')('vows:batch')
@@ -165,7 +167,9 @@ class Batch {
       const err = calledWith[0]
       const results = calledWith.slice(1)
 
-      debug(`Results for topic of '${this.title}': ${err}, ${results.join(', ')}`)
+      // Need to call util.inspect ourselves in case objects have a null prototype
+      // ES6 modules in particular do this.
+      debug(`Results for topic of '${this.title}': ${err}, ${results.map(util.inspect).join(', ')}`)
 
       this.runTests(err, results)
       this.report.successes = _.keys(this.tests).length - this.report.failures
@@ -265,7 +269,7 @@ class Batch {
     if (_.size(this.tests) > 0) {
       const args = _.concat([err], results)
 
-      debug(`Passing args '${args.join(', ')}' to tests for batch '${this.title}'`)
+      debug(`Passing args '${args.map(util.inspect).join(', ')}' to tests for batch '${this.title}'`)
 
       for (const name in this.tests) {
         const test = this.tests[name]
@@ -307,7 +311,7 @@ class Batch {
     } else {
       const batchArgs = _.concat(_.clone(results), args)
 
-      debug(`Passing args '${batchArgs.join(', ')}' to batches for '${this.title}'`)
+      debug(`Passing args '${batchArgs.map(util.inspect).join(', ')}' to batches for '${this.title}'`)
 
       const runBatch = (sub, callback) => {
         sub.run(batchArgs, (err, report) => {

--- a/lib/batch.js
+++ b/lib/batch.js
@@ -18,7 +18,7 @@
 
 'use strict'
 
-const util = require('node:util');
+const util = require('util');
 
 const _ = require('lodash')
 const async = require('async')

--- a/test/test-null-prototype-topic.js
+++ b/test/test-null-prototype-topic.js
@@ -1,0 +1,32 @@
+// test-static-topic.js -- A topic that has a null prototype
+//
+// Copyright 2018 Fuzzy.ai <evan@fuzzy.ai>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict'
+
+const vows = require('../lib/index')
+const assert = vows.assert
+
+vows.describe('topic that has a null prototype')
+  .addBatch({
+    'When we use a topic with a null prototype': {
+      topic: Object.create(null),
+      'it works' (err, data) {
+        assert.ifError(err)
+        assert.isObject(data)
+      }
+    }
+  })
+  .export(module)


### PR DESCRIPTION
See the inline comment - impetus here is that if you `require()` an ES6 module, you get an Object with its prototype set to `null`, which results in this crash:

```
[snipped]
  vows:batch Beginning topic of batch 'When we get the conference space planner module' +0ms
  vows:batch Completed topic of batch 'When we get the conference space planner module' +17ms
  vows:batch Results of topic of batch 'When we get the conference space planner module' defined and not a Promise; running sync +0ms
  vows:at-most-once First call of atMostOnce() wrapper of bound () +17ms
/var/home/alex/Development/patch/node_modules/vows/lib/batch.js:164
      debug(`Results for topic of '${this.title}': ${err}, ${results.join(', ')}`)
                                                                     ^

TypeError: Cannot convert object to primitive value
    at Array.join (<anonymous>:null:null)
    at Batch.<anonymous> (/var/home/alex/Development/patch/node_modules/vows/lib/batch.js:164:70)
[snipped]
```

Because there's no `toString` on the module object, type coercion fails.